### PR TITLE
Enhancement + possible fix in config.js template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file is used to list changes made in each version of grafana.
 
+
+1.0.2:
+
+- Iiro Niinikoski
+  * Forked cookbook
+  * config.js: removed the strict (did not work at all with that) and changed the GraphiteHost to be assigned from the role search 
+
+
+
 ## 1.0.1:
 
 * Update file release to 1.5.0

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jonathan@tron.name'
 license          'Apache 2.0'
 description      'Installs/Configures grafana'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.1'
+version          '1.0.2'
 
 %w{git nginx ark}.each do |cb|
   depends cb

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -5,7 +5,6 @@
  */
 define(['settings'],
 function (Settings) {
-  "use strict";
 
   return new Settings({
 
@@ -22,7 +21,7 @@ function (Settings) {
      * in nginx or apache for cross origin domain sharing to work (CORS).
      * Check install documentation on github
      */
-    graphiteUrl: window.location.protocol+"//"+window.location.hostname+":"+window.location.port+"/_graphite",
+    graphiteUrl: "http://<%= node['grafana']['graphite_server'] %>:80", 
 
     /**
      * Multiple graphite servers? Comment out graphiteUrl and replace with


### PR DESCRIPTION
Changes:
- config.js
  - Graphite host comes now from role search
  - removed the "use strict"; for some reason the Grafana didn´t load at all with that one...

I used version 1.5.1 of Grafana - installed from zip file.
