### PR TITLE
Avoid normal attributes where simple override works

### DIFF
--- a/attributes/nginx.rb
+++ b/attributes/nginx.rb
@@ -1,3 +1,6 @@
 default['grafana']['nginx']['template'] = 'grafana-nginx.conf.erb'
 default['grafana']['nginx']['template_cookbook'] = 'grafana'
-default['grafana']['nginx']['enable_default_site'] = false
+
+include_attributes 'nginx'
+
+default['nginx']['enable_default_site'] = false

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -19,8 +19,6 @@
 
 require "base64"
 
-node.set['nginx']['default_site_enabled'] = node['grafana']['nginx']['enable_default_site']
-
 include_recipe "nginx"
 
 es_basic_auth = if !node['grafana']['es_user'].empty? && !node['grafana']['es_password'].empty?


### PR DESCRIPTION
A new upload of nodes file (or knife node edit) might be needed to reset
the normal attributes.
