### PR TITLE
Allow attribute configuration for datasources

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,3 +49,16 @@ default['grafana']['timezone_offset'] = 'null' # Example: "-0500" (for UTC - 5 h
 default['grafana']['grafana_index'] = 'grafana-index'
 default['grafana']['unsaved_changes_warning'] = 'true'
 default['grafana']['playlist_timespan'] = '1m'
+default['grafana']['datasources'] = {
+  'graphite' => {
+    'type' => "'graphite'",
+    'url'  => 'window.location.protocol+"//"+window.location.hostname+":"+window.location.port+"/_graphite"',
+    'default' => true
+  },
+  'elasticsearch' => {
+    'type' => "'elasticsearch'",
+    'url'  => 'window.location.protocol+"//"+window.location.hostname+":"+window.location.port',
+    'index' => "'#{node['grafana']['grafana_index']}'",
+    'grafanaDB' => true
+  }
+}

--- a/libraries/javascript_pp.rb
+++ b/libraries/javascript_pp.rb
@@ -1,0 +1,20 @@
+module JavascriptPP
+  def pprint(obj, indent=1)
+    case obj
+    when Hash
+      res = "{\n"
+      obj.each do |k,v|
+        res += "  " * indent
+        res += k.to_s + ": "
+        res += pprint(v, indent+1)
+        res += ",\n"
+      end
+      res.gsub!(/,\n$/, "\n")
+      res += "  " * (indent - 1)
+      res += "}"
+    else
+      res = obj.to_s
+    end
+    res
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,8 +42,12 @@ include_recipe "grafana::_install_#{node['grafana']['install_type']}"
 template "#{node['grafana']['web_dir']}/config.js" do
   source node['grafana']['config_template']
   cookbook node['grafana']['config_cookbook']
+  variables({
+    'datasources' => node['grafana']['datasources'],
+  })
   mode '0644'
   user grafana_user
+  helpers(::JavascriptPP)
 end
 
 unless node['grafana']['webserver'].empty?

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -3,25 +3,14 @@
  // config.js is where you will find the core Grafana configuration. This file contains parameter that
  // must be set before Grafana is run for the first time.
  ///
+<% require 'json' %>
 define(['settings'],
 function (Settings) {
-
 
   return new Settings({
 
     // datasources, you can add multiple
-    datasources: {
-      graphite: {
-        type: 'graphite',
-        url: window.location.protocol+"//"+window.location.hostname+":"+window.location.port+"/_graphite",
-        default: true
-      }
-    },
-
-    // elasticsearch url
-    // used for storing and loading dashboards, optional
-    // For Basic authentication use: http://username:password@domain.com:9200
-    elasticsearch: window.location.protocol+"//"+window.location.hostname+":"+window.location.port,
+    datasources: <%= pprint(@datasources,3) %>,
 
     // default start dashboard
     default_route: '/dashboard/file/default.json',
@@ -38,16 +27,12 @@ function (Settings) {
     //
     timezoneOffset: <%= node['grafana']['timezone_offset'] %>,
 
-    // Elasticsearch index for storing dashboards
-    grafana_index: "<%= node['grafana']['grafana_index'] %>",
-
     // set to false to disable unsaved changes warning
     unsaved_changes_warning: <%= node['grafana']['unsaved_changes_warning'] %>,
 
     // set the default timespan for the playlist feature
     // Example: "1m", "1h"
     playlist_timespan: "<%= node['grafana']['playlist_timespan'] %>",
-
 
     // Add your own custom pannels
     plugins: {


### PR DESCRIPTION
NB: String attributes must be written litteraly :
type => "'graphite'"

This change is backward compatible
