### PR TITLE
Corrects the install type to 'file' instead of 'zipfile'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ As with most cookbooks I write, this one is hopefully flexible enough to be wrap
 
 #### grafana::default
 
-- `node['grafana']['install_type']` - The type of install we are going to use either `git` or `zipfile`
+- `node['grafana']['install_type']` - The type of install we are going to use either `git` or `file`
 - `node['grafana']['git']['url']` - The url for the git repo to use for Grafana
 - `node['grafana']['git']['branch']` - The sha or branch name to use
 - `node['grafana']['file']['type']` - the type of archive file.  `zip` only at this stage
@@ -64,7 +64,7 @@ The default recipe will:
 - install Grafana from `master` into `/opt/grafana/master` and create a symlink called `current` in the same directory to `master`
 - install `nginx` and serve the grafana application
 
-If you want to use the zipfile distribution of Grafana update `node['grafana']['install_type']` attribute to `zipfile`.  Set `node['grafana']['zipfile_checksum']` to appropriate sha256 value of latest zipfile.
+If you want to use the zipfile distribution of Grafana update `node['grafana']['install_type']` attribute to `file`.  Set `node['grafana']['zipfile_checksum']` to appropriate sha256 value of latest zipfile.
 
 If you don't want this cookbook to handle the webserver config simply set `node['grafana']['webserver']` to `''` in a role/environment/node somewhere.
 Please note that in this case you have to set `node['grafana']['user']`.


### PR DESCRIPTION
Ran into this while switching back to the zipfile installation from a git installation. Looks like this attribute should be set to `file` instead of `zipfile`, so I updated the README to correct this.

Thanks for the cookbook :)
