### PR TITLE
fix role specification for elasticsearch and graphite

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,14 +17,14 @@
 # limitations under the License.
 #
 
-unless Chef::Config[:solo] || node['grafana']['es_server']
+unless Chef::Config[:solo] || node['grafana']['es_role'].nil?
   es_server_results = search(:node, "roles:#{node['grafana']['es_role']} AND chef_environment:#{node.chef_environment}")
   unless es_server_results.empty?
     node.default['grafana']['es_server'] = es_server_results.first['ipaddress']
   end
 end
 
-unless Chef::Config[:solo] || node['grafana']['graphite_server']
+unless Chef::Config[:solo] || node['grafana']['graphite_role'].nil?
   graphite_server_results = search(:node, "roles:#{node['grafana']['graphite_role']} AND chef_environment:#{node.chef_environment}")
   unless graphite_server_results.empty?
     node.default['grafana']['graphite_server'] = graphite_server_results.first['ipaddress']


### PR DESCRIPTION
This change fixes the ability to dynamically configure the remote end points for graphite and elasticsearch. I could not figure out how the original method was supposed to work given that the `es_server` and `graphite_server` had default variables defined in `attributes/default.rb`
