### PR TITLE
support grafana admin password option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default['grafana']['file']['checksum'] = '08a923508d1a0ef2af4c23827e715e438240d3
 default['grafana']['webserver'] = 'nginx'
 default['grafana']['install_path'] = '/srv/apps'
 default['grafana']['install_dir'] = "#{node['grafana']['install_path']}/grafana"
+default['grafana']['admin_password'] = ''
 
 case node['grafana']['install_type']
 when 'git'

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -34,6 +34,12 @@ function (Settings) {
     // Example: "1m", "1h"
     playlist_timespan: "<%= node['grafana']['playlist_timespan'] %>",
 
+    // If you want to specify password before saving, please specify it bellow
+    // The purpose of this password is not security, but to stop some users from accidentally changing dashboards
+    admin: {
+      password: '<%= node['grafana']['admin_password'] %>'
+    },
+
     // Change window title prefix from 'Grafana - <dashboard title>'
     window_title_prefix: "<%= node['grafana']['window_title_prefix'] %>",
 


### PR DESCRIPTION
Adds a new attribute: node[:grafana][:admin_password] 

Default value is an empty string which keeps the previous behavior (no password required). 

When a password is set, this new grafana feature will be used to prevent accidental modification of dashboards by users: https://github.com/grafana/grafana/issues/606

Tested with the default value and with an overriding value. 
