### PR TITLE
Evaluate derived datasource attributes correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,15 @@ to know about the multiple databases it should read data from (`elasticsearch`,
   'elasticsearch' => {
     'type' => "'elasticsearch'",
     'url'  => 'window.location.protocol+"//"+window.location.hostname+":"+window.location.port',
-    'index' => "'#{node['grafana']['grafana_index']}'",
+    'index' => lambda { "'#{node['grafana']['grafana_index']}'" },
     'grafanaDB' => true
   }
 }
 ```
+
+**NOTE**
+Any derived attributes should be wrapped in a lambda if you expect to change
+the value of the root attribute (see example above).
 
 #### kibana::nginx
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,7 +62,7 @@ default['grafana']['datasources'] = {
   'elasticsearch' => {
     'type' => "'elasticsearch'",
     'url'  => 'window.location.protocol+"//"+window.location.hostname+":"+window.location.port',
-    'index' => "'#{node['grafana']['grafana_index']}'",
+    'index' => -> { "'#{node['grafana']['grafana_index']}'" },
     'grafanaDB' => true
   }
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,7 +62,7 @@ default['grafana']['datasources'] = {
   'elasticsearch' => {
     'type' => "'elasticsearch'",
     'url'  => 'window.location.protocol+"//"+window.location.hostname+":"+window.location.port',
-    'index' => -> { "'#{node['grafana']['grafana_index']}'" },
+    'index' => lambda { "'#{node['grafana']['grafana_index']}'" },
     'grafanaDB' => true
   }
 }

--- a/libraries/javascript_pp.rb
+++ b/libraries/javascript_pp.rb
@@ -12,6 +12,8 @@ module JavascriptPP
       res.gsub!(/,\n$/, "\n")
       res += '  ' * (indent - 1)
       res += '}'
+    when Proc
+      res = obj.call.to_s
     else
       res = obj.to_s
     end


### PR DESCRIPTION
Fixes #25.

It made sense to me to support lambdas identification/calling in `JavascriptPP.pprint` since the `datasources` mash gets passed to a helper method when building the javascript config. This allows us to evaluate the `default['griffin']['grafana_index']` attribute, and any other for that matter, at the time the config is generated.
