### PR TITLE
Allowed missing listen_address

### DIFF
--- a/templates/default/grafana-nginx.conf.erb
+++ b/templates/default/grafana-nginx.conf.erb
@@ -1,5 +1,5 @@
 server {
-  listen                <%= @listen_address %>:<%= @listen_port %>;
+  listen                <%= "#{@listen_address}:" if @listen_address %><%= @listen_port %>;
 
   server_name           <%= @server_name %> <%= @server_aliases.join(" ") %>;
   access_log            /var/log/nginx/<%= @server_name %>.access.log;


### PR DESCRIPTION
When `node['grafana']['webserver_listen']` is unspecified, will listen on all addresses
