### PR TITLE
update link to elasticsearch cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -10,4 +10,4 @@ cookbook 'ark', '>= 0.7.2'
 cookbook 'graphite', '~> 1.0.2'
 cookbook 'build-essential'
 
-cookbook 'elasticsearch', git: 'git://github.com/elasticsearch/cookbook-elasticsearch.git'
+cookbook 'elasticsearch', git: 'git://github.com/elastic/cookbook-elasticsearch.git'


### PR DESCRIPTION
The link doesn't seem to be following the redirect after ES changed their name to Elastic.

I've run a few of the kitchen tests to ensure that Berks is downloading the dep correctly now.
