### PR TITLE
nginx template listen_address fix

### DIFF
--- a/templates/default/grafana-nginx.conf.erb
+++ b/templates/default/grafana-nginx.conf.erb
@@ -1,5 +1,5 @@
 server {
-  listen                <%= "#{@listen_address}:" if @listen_address %><%= @listen_port %>;
+  listen                <%= "#{@listen_address}:" if !@listen_address.nil? && !@listen_address.empty? %><%= @listen_port %>;
 
   server_name           <%= @server_name %> <%= @server_aliases.join(" ") %>;
   access_log            /var/log/nginx/<%= @server_name %>.access.log;

--- a/test/integration/default/serverspec/Gemfile
+++ b/test/integration/default/serverspec/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gem 'serverspec'
+gem 'ohai'

--- a/test/integration/default/serverspec/spec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/spec/localhost/default_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require ::File.expand_path('../../spec_helper', __FILE__)
 
 describe file('/srv/apps/grafana') do
   let :owner do
@@ -106,4 +106,8 @@ describe file('/etc/nginx/sites-enabled/grafana') do
   it { should be_linked_to '/etc/nginx/sites-available/grafana' }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
+end
+
+describe command("curl http://#{$ohaidata[:ipaddress]}/#/dashboard/file/default.json") do
+  its(:stdout) { should match /GrafanaCtrl/ }
 end

--- a/test/integration/default/serverspec/spec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'serverspec'
+require 'ohai'
 
 set :backend, :exec
 
@@ -10,3 +11,7 @@ RSpec.configure do |c|
     c.sudo_password = ENV['SUDO_PASSWORD']
   end
 end
+
+ohai = Ohai::System.new
+ohai.all_plugins
+$ohaidata = ohai.data


### PR DESCRIPTION
This PR contains a fix to the `grafana-nginx.conf.erb` so that an empty or nil `node['grafana']['listen_address']` will render correctly.

It also contains enhanced tests to illustrate #33. Setting `node['grafana']['listen_address']` to nil (assuming this patch is accepted) should address the issue discussed in #33.
