### PR TITLE
Do not start grafana while config is not present

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,7 +50,7 @@ template '/etc/default/grafana-server' do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :restart, 'service[grafana-server]', :immediate
+  notifies :restart, 'service[grafana-server]', :delayed
 end
 
 template "#{node['grafana']['conf_dir']}/grafana.ini" do


### PR DESCRIPTION
It leads to grafana looks at default configuration, and populating the database with theses settings, so if you set the admin_password, it would have no effect, as the password would have already been written to database.
This patch fixes it.
