### PR TITLE
FIX: Removing unnecessary services reboots

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -68,5 +68,5 @@ template "#{node['grafana']['conf_dir']}/grafana.ini" do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :restart, 'service[grafana-server]', :immediate
+  notifies [ :enable, :restart ], 'service[grafana-server]', :immediate
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,11 @@
 # limitations under the License.
 #
 
+service 'grafana-server' do
+  supports start: true, stop: true, restart: true, status: true, reload: false
+  action :nothing
+end
+
 unless node['grafana']['webserver'].empty?
   include_recipe "grafana::_#{node['grafana']['webserver']}"
 end
@@ -50,7 +55,6 @@ template '/etc/default/grafana-server' do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :restart, 'service[grafana-server]', :delayed
 end
 
 ini = node['grafana']['ini'].dup
@@ -65,9 +69,4 @@ template "#{node['grafana']['conf_dir']}/grafana.ini" do
   group 'root'
   mode '0644'
   notifies :restart, 'service[grafana-server]', :immediate
-end
-
-service 'grafana-server' do
-  supports start: true, stop: true, restart: true, status: true, reload: false
-  action [:enable, :start]
 end


### PR DESCRIPTION
The grafana-server is startted and restarted at every template configuration when we just need it to start at the end of the process. This modification creates the service with an action :nothing and only calls the restart at the end of the configuration.
