### PR TITLE
Problem trying to start a service already online

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,11 @@ end
 
 include_recipe "grafana::_install_#{node['grafana']['install_type']}"
 
+service 'grafana-server' do
+  supports start: true, stop: true, restart: true, status: true, reload: false
+  action :enable
+end
+
 directory node['grafana']['data_dir'] do
   owner node['grafana']['user']
   group node['grafana']['group']
@@ -50,7 +55,6 @@ template '/etc/default/grafana-server' do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :restart, 'service[grafana-server]', :delayed
 end
 
 ini = node['grafana']['ini'].dup
@@ -65,9 +69,4 @@ template "#{node['grafana']['conf_dir']}/grafana.ini" do
   group 'root'
   mode '0644'
   notifies :restart, 'service[grafana-server]', :immediate
-end
-
-service 'grafana-server' do
-  supports start: true, stop: true, restart: true, status: true, reload: false
-  action [:enable, :start]
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ include_recipe "grafana::_install_#{node['grafana']['install_type']}"
 
 service 'grafana-server' do
   supports start: true, stop: true, restart: true, status: true, reload: false
-  action [ :enable, :start ]
+  action [:enable, :start]
 end
 
 directory node['grafana']['data_dir'] do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ include_recipe "grafana::_install_#{node['grafana']['install_type']}"
 
 service 'grafana-server' do
   supports start: true, stop: true, restart: true, status: true, reload: false
-  action :enable
+  action [ :enable, :start ]
 end
 
 directory node['grafana']['data_dir'] do


### PR DESCRIPTION
I've got an error telling the recipe last statement was trying to start a service that is already started. This PR fix it by removing all :start and :restarts in the midle of the configuration witch means the server is not really prepared to be started yet. This modification creates the service just after the installation with an action :enable and only calls for a :restart at the end of the configuration. I used :restart and not :start because the error Chef could give if the server, after the installation, became on-line from other recipes of because its the default in the install process.

This is the error I've got:

```
---TRUNCATED---
    -#################################### AMPQ Event Publisher ##########################
    -[event_publisher]
    -;enabled = false
    -;rabbitmq_url = amqp://localhost/
    -;exchange = grafana_events
    +[paths]
    +data = /var/lib/grafana
    +logs = /var/log/grafana
  * service[grafana-server] action restart
    - restart service service[grafana-server]
  * service[grafana-server] action enable
    - enable service service[grafana-server]
  * service[grafana-server] action start

    ================================================================================
    Error executing action `start` on resource 'service[grafana-server]'
    ================================================================================

    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '1'
    ---- Begin output of /etc/init.d/grafana-server start ----
    STDOUT: * Starting Grafana Server
       ...fail!
    STDERR:
    ---- End output of /etc/init.d/grafana-server start ----
    Ran /etc/init.d/grafana-server start returned 1

    Resource Declaration:
    ---------------------
    # In /home/helio.andrade/chef-solo/cookbooks-3/grafana/recipes/default.rb

     70: service 'grafana-server' do
     71:   supports start: true, stop: true, restart: true, status: true, reload: false
     72:   action [:enable, :start]
     73: end

    Compiled Resource:
    ------------------
    # Declared in /home/helio.andrade/chef-solo/cookbooks-3/grafana/recipes/default.rb:70:in `from_file'

    service("grafana-server") do
      action [:enable, :start]
      updated true
      supports {:start=>true, :stop=>true, :restart=>true, :status=>true, :reload=>false}
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      service_name "grafana-server"
      enabled true
      running true
      pattern "grafana-server"
      declared_type :service
      cookbook_name :grafana
      recipe_name "default"
    end
---TRUNCATED---
```
