### PR TITLE
improve user management

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source 'https://api.berkshelf.com'
+source 'https://supermarket.chef.io'
 
 metadata
 

--- a/README.md
+++ b/README.md
@@ -208,12 +208,14 @@ This resource will allow you to create global users within Grafana. This resourc
 More information about creating Grafana users via the HTTP API can be found [here](http://docs.grafana.org/reference/http_api/#users).
 
 #### Attributes
-| Attribute      | Type     | Default Value       | Description                       |
-|----------------|:--------:|:-------------------:|-----------------------------------|
-| `host`         | `String` | `'localhost'`       | The host grafana is running on    |
-| `port`         | `Integer`| `3000`              | The port grafana is running on    |
-| `user`         | `String` | `'admin'`           | A grafana user with admin privileges |
-| `password`     | `String` | `'admin'`           | The grafana user's password       |
+| Attribute      | Type     | Default Value       | Description                                              |
+|----------------|:--------:|:-------------------:|----------------------------------------------------------|
+| `host`         | `String` | `'localhost'`       | The host grafana is running on                           |
+| `port`         | `Integer`| `3000`              | The port grafana is running on                           |
+| `admin_user`   | `String` | `'admin'`           | A grafana user with admin privileges                     |
+| `adminpassword`| `String` | `'admin'`           | The grafana user's password                              |
+| `user`         | `Hash  ` | `{}`                | A Hash of the values to create the user. Examples below. |
+
 | `global`       | `boolean`| `true`              | Whether you want the user to be a global user. _Currently only global `true` is supported._ |
 | `admin`        | `boolean`| `false`             | Whether or not the user should be a global admin. _Currently only admin `false` is supported._ |
 | `login`        | `String` |                     | The login for this user. Defaults to the name used in the resource invocation. |
@@ -226,10 +228,48 @@ More information about creating Grafana users via the HTTP API can be found [her
 Assuming you would like to create a new user...
 
 ```ruby
-grafana_user 'person2' do
-  full_name 'John Smith'
-  email 'test@example.com'
-  passwd 'test123'
+grafana_user 'j.smith' do
+  user(
+    name: 'John Smith',
+    email: 'test@example.com',
+    password: 'test123',
+    isAdmin: true
+  )
+  action :create
+end
+```
+User's login property is not mandatory. DEfault goes to resource name.
+
+To update user's details, password and permissions
+```ruby
+grafana_user 'j.smith' do
+  user(
+    name: 'John Smith',
+    email: 'test@example.com',
+    password: 'test1234',
+    isAdmin: false
+  )
+  action :update
+end
+```
+
+To update user's login, use current login as resource name and new login as user property, like:
+```ruby
+grafana_user 'j.smith' do
+  user(
+    name: 'John Smith',
+    login: 'john.smith',
+    email: 'test@example.com',
+    password: 'test1234',
+    isAdmin: false
+  )
+  action :update
+end
+```
+And finally to delete a user
+```ruby
+grafana_user 'john.smith' do
+  action :delete
 end
 ```
 

--- a/libraries/user_api.rb
+++ b/libraries/user_api.rb
@@ -2,7 +2,6 @@ module GrafanaCookbook
   module UserApi
     include GrafanaCookbook::ApiHelper
 
-    #
     def add_user(user, grafana_options)
       session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
       http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
@@ -26,7 +25,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def update_user_details(user, grafana_options)
       session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
       http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])

--- a/libraries/user_api.rb
+++ b/libraries/user_api.rb
@@ -3,47 +3,25 @@ module GrafanaCookbook
     include GrafanaCookbook::ApiHelper
 
     def add_user(user, grafana_options)
-      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
-      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
-      request = Net::HTTP::Post.new('/api/admin/users')
-      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
-      request.add_field('Content-Type', 'application/json;charset=utf-8;')
-      request.body = user.to_json
+      grafana_options[:method] = 'Post'
+      grafana_options[:success_msg] = 'The user has been successfully created.'
+      grafana_options[:unknown_code_msg] = 'UserApi::add_user unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/admin/users'
+      grafana_options[:accept_header] = 'application/json;charset=utf-8;'
 
-      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
-        http.request(request)
-      end
-
-      handle_response(
-        request,
-        response,
-        success: 'The user has been successfully created.',
-        unknown_code: 'UserApi::add_user unchecked response code: %{code}'
-      )
-      JSON.parse(response.body)
+      do_request(grafana_options, user.to_json)
     rescue BackendError
       nil
     end
 
     def update_user_details(user, grafana_options)
-      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
-      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
-      request = Net::HTTP::Put.new('/api/users/' + user[:id].to_s)
-      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
-      request.add_field('Content-Type', 'application/json;charset=utf-8;')
-      request.body = user.to_json
+      grafana_options[:method] = 'Put'
+      grafana_options[:success_msg] = 'The user has been successfully updated.'
+      grafana_options[:unknown_code_msg] = 'UserApi::update_user unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/users/' + user[:id].to_s
+      grafana_options[:accept_header] = 'application/json;charset=utf-8;'
 
-      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
-        http.request(request)
-      end
-
-      handle_response(
-        request,
-        response,
-        success: 'The user has been successfully updated.',
-        unknown_code: 'UserApi::update_user unchecked response code: %{code}'
-      )
-      JSON.parse(response.body)
+      do_request(grafana_options, user.to_json)
     rescue BackendError
       nil
     end
@@ -55,59 +33,58 @@ module GrafanaCookbook
       return if user_session_id
 
       # If it fails, that means we have to change password
-      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
-      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
-      request = Net::HTTP::Put.new('/api/admin/users/' + user[:id].to_s + '/password')
-      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
-      request.add_field('Content-Type', 'application/json;charset=utf-8;')
-      request.body = { password: user[:password] }.to_json
+      grafana_options[:method] = 'Put'
+      grafana_options[:success_msg] = 'User\'s password has been successfully updated.'
+      grafana_options[:unknown_code_msg] = 'UserApi::update_user unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/admin/users/' + user[:id].to_s + '/password'
+      grafana_options[:accept_header] = 'application/json;charset=utf-8;'
 
-      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
-        http.request(request)
-      end
-
-      handle_response(
-        request,
-        response,
-        success: 'The user has been successfully updated.',
-        unknown_code: 'UserApi::update_user unchecked response code: %{code}'
-      )
-      JSON.parse(response.body)
+      do_request(grafana_options, { password: user[:password] }.to_json)
     rescue BackendError
       nil
     end
 
     def update_user_permissions(user, grafana_options)
-      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
-      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
-      request = Net::HTTP::Put.new('/api/admin/users/' + user[:id].to_s + '/permissions')
-      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
-      request.add_field('Content-Type', 'application/json;charset=utf-8;')
-      request.body = { isGrafanaAdmin: user[:isAdmin] }.to_json
+      grafana_options[:method] = 'Put'
+      grafana_options[:success_msg] = 'User\'s permissions have been successfully updated'
+      grafana_options[:unknown_code_msg] = 'UserApi::update_user unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/admin/users/' + user[:id].to_s + '/permissions'
+      grafana_options[:accept_header] = 'application/json;charset=utf-8;'
 
-      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
-        http.request(request)
-      end
-
-      handle_response(
-        request,
-        response,
-        success: 'The user has been successfully updated.',
-        unknown_code: 'UserApi::update_user unchecked response code: %{code}'
-      )
-      JSON.parse(response.body)
+      do_request(grafana_options, { isGrafanaAdmin: user[:isAdmin] }.to_json)
     rescue BackendError
       nil
     end
 
-    #
     def delete_user(user, grafana_options)
+      grafana_options[:method] = 'Delete'
+      grafana_options[:success_msg] = 'The user has been successfully deleted.'
+      grafana_options[:unknown_code_msg] = 'UserApi::delete_user unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/admin/users/' + user[:id].to_s
+      grafana_options[:accept_header] = 'application/json;charset=utf-8;'
+
+      do_request(grafana_options, user.to_json)
+    rescue BackendError
+      nil
+    end
+
+    def do_request(grafana_options, payload=nil)
       session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
       http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
-      request = Net::HTTP::Delete.new('/api/admin/users/' + user[:id].to_s)
+      case grafana_options[:method]
+      when 'Post'
+        request = Net::HTTP::Post.new(grafana_options[:endpoint])
+      when 'Put'
+        request = Net::HTTP::Put.new(grafana_options[:endpoint])
+      when 'Delete'
+        request = Net::HTTP::Delete.new(grafana_options[:endpoint])
+      else
+        request = Net::HTTP::Get.new(grafana_options[:endpoint])
+      end
       request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
       request.add_field('Content-Type', 'application/json;charset=utf-8;')
-      request.body = user.to_json
+      request.add_field('Accept', 'application/json')
+      request.body = payload if payload
 
       response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
         http.request(request)
@@ -116,34 +93,23 @@ module GrafanaCookbook
       handle_response(
         request,
         response,
-        success: 'The user has been successfully deleted.',
-        unknown_code: 'UserApi::delete_user unchecked response code: %{code}'
+        success: grafana_options[:success_msg],
+        unknown_code: grafana_options[:unknown_code_msg]
       )
       JSON.parse(response.body)
     rescue BackendError
       nil
     end
 
-    # Gets a list of users
     # curl -G --cookie "grafana_user=admin; grafana_sess=5eca2376d310627f;" http://localhost:3000/api/users
     def get_user_list(grafana_options)
-      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
-      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
-      request = Net::HTTP::Get.new('/api/users/')
-      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
-      request.add_field('Accept', 'application/json')
+      grafana_options[:method] = 'Get'
+      grafana_options[:success_msg] = 'The list of users has been successfully retrieved.'
+      grafana_options[:unknown_code_msg] = 'UserApi::get_admin_user_list unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/users/'
+      grafana_options[:accept_header] = 'application/json'
 
-      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
-        http.request(request)
-      end
-
-      handle_response(
-        request,
-        response,
-        success: 'The list of users has been successfully retrieved.',
-        unknown_code: 'UserApi::get_admin_user_list unchecked response code: %{code}'
-      )
-      JSON.parse(response.body)
+      do_request(grafana_options)
     rescue BackendError
       nil
     end

--- a/libraries/user_api.rb
+++ b/libraries/user_api.rb
@@ -3,13 +3,13 @@ module GrafanaCookbook
     include GrafanaCookbook::ApiHelper
 
     #
-    def add_global_user(person, grafana_options)
+    def add_user(user, grafana_options)
       session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
       http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
       request = Net::HTTP::Post.new('/api/admin/users')
       request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
       request.add_field('Content-Type', 'application/json;charset=utf-8;')
-      request.body = person.to_json
+      request.body = user.to_json
 
       response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
         http.request(request)
@@ -18,21 +18,120 @@ module GrafanaCookbook
       handle_response(
         request,
         response,
-        success: 'The admin user has been successfully created.',
-        unknown_code: 'UserApi::add_admin_user unchecked response code: %{code}'
+        success: 'The user has been successfully created.',
+        unknown_code: 'UserApi::add_user unchecked response code: %{code}'
       )
-
       JSON.parse(response.body)
     rescue BackendError
       nil
     end
 
-    # Gets a list of global users
-    # curl -G --cookie "grafana_user=admin; grafana_sess=5eca2376d310627f;" http://localhost:3000/api/admin/users
-    def get_global_user_list(grafana_options)
+    #
+    def update_user_details(user, grafana_options)
       session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
       http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
-      request = Net::HTTP::Get.new('/api/admin/users')
+      request = Net::HTTP::Put.new('/api/users/' + user[:id].to_s)
+      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
+      request.add_field('Content-Type', 'application/json;charset=utf-8;')
+      request.body = user.to_json
+
+      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
+        http.request(request)
+      end
+
+      handle_response(
+        request,
+        response,
+        success: 'The user has been successfully updated.',
+        unknown_code: 'UserApi::update_user unchecked response code: %{code}'
+      )
+      JSON.parse(response.body)
+    rescue BackendError
+      nil
+    end
+
+    def update_user_password(user, grafana_options)
+      # Test user login with provided password.
+      # If it succeeds, no need to update password
+      user_session_id = login(grafana_options[:host], grafana_options[:port], user[:login], user[:password])
+      return if user_session_id
+
+      # If it fails, that means we have to change password
+      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
+      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
+      request = Net::HTTP::Put.new('/api/admin/users/' + user[:id].to_s + '/password')
+      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
+      request.add_field('Content-Type', 'application/json;charset=utf-8;')
+      request.body = { password: user[:password] }.to_json
+
+      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
+        http.request(request)
+      end
+
+      handle_response(
+        request,
+        response,
+        success: 'The user has been successfully updated.',
+        unknown_code: 'UserApi::update_user unchecked response code: %{code}'
+      )
+      JSON.parse(response.body)
+    rescue BackendError
+      nil
+    end
+
+    def update_user_permissions(user, grafana_options)
+      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
+      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
+      request = Net::HTTP::Put.new('/api/admin/users/' + user[:id].to_s + '/permissions')
+      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
+      request.add_field('Content-Type', 'application/json;charset=utf-8;')
+      request.body = { isGrafanaAdmin: user[:isAdmin] }.to_json
+
+      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
+        http.request(request)
+      end
+
+      handle_response(
+        request,
+        response,
+        success: 'The user has been successfully updated.',
+        unknown_code: 'UserApi::update_user unchecked response code: %{code}'
+      )
+      JSON.parse(response.body)
+    rescue BackendError
+      nil
+    end
+
+    #
+    def delete_user(user, grafana_options)
+      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
+      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
+      request = Net::HTTP::Delete.new('/api/admin/users/' + user[:id].to_s)
+      request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
+      request.add_field('Content-Type', 'application/json;charset=utf-8;')
+      request.body = user.to_json
+
+      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
+        http.request(request)
+      end
+
+      handle_response(
+        request,
+        response,
+        success: 'The user has been successfully deleted.',
+        unknown_code: 'UserApi::delete_user unchecked response code: %{code}'
+      )
+      JSON.parse(response.body)
+    rescue BackendError
+      nil
+    end
+
+    # Gets a list of users
+    # curl -G --cookie "grafana_user=admin; grafana_sess=5eca2376d310627f;" http://localhost:3000/api/users
+    def get_user_list(grafana_options)
+      session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
+      http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
+      request = Net::HTTP::Get.new('/api/users/')
       request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; grafana_sess=#{session_id};")
       request.add_field('Accept', 'application/json')
 
@@ -46,7 +145,6 @@ module GrafanaCookbook
         success: 'The list of users has been successfully retrieved.',
         unknown_code: 'UserApi::get_admin_user_list unchecked response code: %{code}'
       )
-
       JSON.parse(response.body)
     rescue BackendError
       nil

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -26,9 +26,7 @@ action :create do
 
   # Find wether user already exists
   users_list.each do |user|
-    if user['login'] == new_resource.user[:login]
-      exists = true
-    end
+    exists = true if user['login'] == new_resource.user[:login]
     break if exists
   end
 
@@ -64,9 +62,8 @@ action :update do
   # Check wether we have to update user's login
   if new_resource.user[:login] != new_resource.name
     old_login = new_resource.name
-    new_login = new_resource.user[:login]
   else
-    old_login = new_login = new_resource.user[:login]
+    old_login = new_resource.user[:login]
   end
 
   # Find wether user already exists

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -1,3 +1,5 @@
+require 'chef/mash'
+
 include GrafanaCookbook::UserApi
 
 use_inline_resources if defined?(use_inline_resources)
@@ -10,28 +12,85 @@ action :create_if_missing do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
-    user: new_resource.user,
-    password: new_resource.password
+    user: new_resource.admin_user,
+    password: new_resource.admin_password
   }
-  user_options = {
-    name: new_resource.full_name,
-    email: new_resource.email,
-    login: new_resource.login,
-    password: new_resource.passwd
-  }
-  if new_resource.global
-    global_users = get_global_user_list(grafana_options)
+  users_list = get_user_list(grafana_options)
+  exists = false
 
-    exists = false
-    global_users.each do |user|
-      exists = true if user['login'] == new_resource.login
+  users_list.each do |user|
+    if user['login'] == new_resource.user[:login]
+      exists = true
     end
-    unless exists
-      converge_by("Creating global user #{new_resource.login}") do
-        add_global_user(user_options, grafana_options)
+    break if exists
+  end
+  unless exists
+    new_resource.user[:name] = new_resource.name
+    converge_by("Creating user #{new_resource.user[:login]}") do
+      add_user(new_resource.user, grafana_options)
+    end
+    converge_by("Setting permissions #{new_resource.user[:login]}") do
+      update_user_permission(new_resource.user, grafana_options)
+    end
+
+  end
+end
+
+action :update do
+  grafana_options = {
+    host: new_resource.host,
+    port: new_resource.port,
+    user: new_resource.admin_user,
+    password: new_resource.admin_password
+  }
+  users_list = get_user_list(grafana_options)
+  exists = false
+
+  if new_resource.user[:login] != new_resource.name
+    old_login = new_resource.name
+    new_login = new_resource.user[:login]
+  else
+    old_login = new_login = new_resource.user[:login]
+  end
+  users_list.each do |user|
+    if user['login'] == old_login
+      exists = true
+      new_resource.user[:id] = user['id']
+      converge_by("Updating details for user #{new_resource.user[:login]}") do
+        update_user_details(new_resource.user, grafana_options)
+      end
+      converge_by("Updating password for user #{new_resource.user[:login]}") do
+        update_user_password(new_resource.user, grafana_options)
+      end
+      if new_resource.user[:isAdmin] != user['isAdmin']
+        converge_by("Updating permissions for user #{new_resource.user[:login]}") do
+          update_user_permissions(new_resource.user, grafana_options)
+        end
       end
     end
-  else
-    Chef::Log.error 'Non-global user creation is not currently supported'
+    break if exists
+  end
+end
+
+action :delete do
+  grafana_options = {
+    host: new_resource.host,
+    port: new_resource.port,
+    user: new_resource.admin_user,
+    password: new_resource.admin_password
+  }
+  users_list = get_user_list(grafana_options)
+  exists = false
+
+  users_list.each do |user|
+    if user['login'] == new_resource.user[:login]
+      exists = true
+      new_resource.user[:id] = user['id']
+      new_resource.user[:name] = new_resource.name
+      converge_by("Deleting user #{new_resource.user[:login]}") do
+        delete_user(new_resource.user, grafana_options)
+      end
+    end
+    break if exists
   end
 end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,16 +1,14 @@
-actions :create_if_missing
+actions :create_if_missing, :update, :delete
 default_action :create_if_missing
 
 state_attrs :login,
   :admin
 
+# Grafana options
 attribute :host, kind_of: String, default: 'localhost'
 attribute :port, kind_of: Integer, default: 3000
-attribute :user, kind_of: String, default: 'admin'
-attribute :password, kind_of: String, default: 'admin'
-attribute :global, kind_of: [TrueClass, FalseClass], default: true
-attribute :admin, kind_of: [TrueClass, FalseClass], default: false
-attribute :login, kind_of: String, name_attribute: true, required: true
-attribute :full_name, kind_of: String, required: true
-attribute :email, kind_of: String, required: true
-attribute :passwd, kind_of: String, required: true
+attribute :admin_user, kind_of: String, default: 'admin'
+attribute :admin_password, kind_of: String, default: 'admin'
+# Resource properties
+attribute :name, kind_of: String, required: true
+attribute :user, kind_of: Hash, default: {}

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,4 +1,4 @@
-actions :create_if_missing, :update, :delete
+actions :create, :update, :delete
 default_action :create_if_missing
 
 state_attrs :login,


### PR DESCRIPTION
As described in #90 , user management in chef-grafana was lacking some useful features.
This PR aims to rewrite most of the user management provider to provide a consistent exprience with other providers as well as restore a working provider (this PR might closes #82 as well).

Please note that I do not manage user to organizations link. This will be implemented after the organization rewrite.
