### PR TITLE
Option to rebuild the apt cache when adding the grafana repo.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ when 'debian'
   default['grafana']['package']['components'] = ['main']
   default['grafana']['package']['key'] = 'https://packagecloud.io/gpg.key'
   default['grafana']['package']['version'] = node['grafana']['version']
+  default['grafana']['package']['apt_rebuild'] = false
 when 'rhel', 'fedora'
   default['grafana']['package']['repo'] = 'https://packagecloud.io/grafana/stable/el/$releasever/$basearch'
   default['grafana']['package']['key'] = 'https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana'

--- a/recipes/_install_package.rb
+++ b/recipes/_install_package.rb
@@ -26,6 +26,7 @@ when 'debian'
     distribution node['grafana']['package']['distribution']
     components node['grafana']['package']['components']
     key node['grafana']['package']['key']
+    cache_rebuild node['grafana']['package']['apt_rebuild']
   end
 when 'rhel'
   yum_repository 'grafana' do


### PR DESCRIPTION
I was getting an error  when installing grafana from package. It complaining that I would need to use `--force-yes` because the key was missing. A simple `apt-get update` would fix this issue.

So I added an option to rebuild the cache after adding the repo. It defaults to `false` to keep existing behavior. 
