### PR TITLE
Support 'latest' as grafana version attribute

### DIFF
--- a/providers/datasource.rb
+++ b/providers/datasource.rb
@@ -104,5 +104,6 @@ action :delete do
 end
 
 def _legacy_http_semantic
+  return false if node['grafana']['version'] == 'latest'
   Gem::Version.new(node['grafana']['version']) < Gem::Version.new('2.0.3')
 end


### PR DESCRIPTION
README states that 'latest' is supported (and it works fine for installing grafana), but with datasource this error appears:

```
================================================================================
Error executing action `create` on resource 'grafana_datasource[graphite]'
================================================================================

ArgumentError
-------------
Malformed version number string latest


Cookbook Trace:
---------------
/var/lib/aws/opsworks/cache.stage2/cookbooks/grafana/providers/datasource.rb:107:in `_legacy_http_semantic'
/var/lib/aws/opsworks/cache.stage2/cookbooks/grafana/providers/datasource.rb:35:in `block (2 levels) in class_from_file'
/var/lib/aws/opsworks/cache.stage2/cookbooks/grafana/providers/datasource.rb:34:in `block in class_from_file'
```

This patch fixes this error.
