### PR TITLE
Default action is :create

### DIFF
--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,5 +1,5 @@
 actions :create, :update, :delete
-default_action :create_if_missing
+default_action :create
 
 state_attrs :login,
   :admin


### PR DESCRIPTION
There is no method :create_if_missing in provider, so it should be :create.
