### PR TITLE
pass version to the dpkg package provider so upgrades work

### DIFF
--- a/recipes/_install_file.rb
+++ b/recipes/_install_file.rb
@@ -37,6 +37,7 @@ when 'debian'
 
   dpkg_package "grafana-#{node['grafana']['version']}" do
     source "#{Chef::Config[:file_cache_path]}/grafana-#{node['grafana']['version']}.deb"
+    version node['grafana']['version']
     action :install
     options '--force-confdef,confnew'
     not_if grafana_installed


### PR DESCRIPTION
Addresses https://github.com/JonathanTron/chef-grafana/issues/102. Makes it so package upgrades work when using the file install method on Debain based distros.
