### PR TITLE
Add an attribute to stop the cookbook managing the installation of the grafana package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ As with most cookbooks, this one is hopefully flexible enough to be wrapped by a
 
 | Attribute                                    | Default                                | Description                       |
 |----------------------------------------------|:--------------------------------------:|-----------------------------------|
+| `node['grafana']['manage_install']`          | `true`                                 | Whether or not the installation should be managed by this cookbook. |
 | `node['grafana']['install_type']`            | `'file'`                               | The type of install: `file`, `package` or `source`. *Note*: `source` is not currently supported. |
 | `node['grafana']['version']`                 | `'2.1.2'`                              | The version to install. For the most recent versions use `'latest'`. |
 | `node['grafana']['file']['url']`             | `'https://grafanarel.s3.amazonaws.com/builds/grafana'` | The file URL for Grafana builds |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+default['grafana']['manage_install'] = true
 default['grafana']['install_type'] = 'file' # file | package | source
 default['grafana']['version'] = '2.1.2'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,9 @@ unless node['grafana']['webserver'].empty?
   include_recipe "grafana::_#{node['grafana']['webserver']}"
 end
 
-include_recipe "grafana::_install_#{node['grafana']['install_type']}"
+if node['grafana']['manage_install']
+  include_recipe "grafana::_install_#{node['grafana']['install_type']}"
+end
 
 service 'grafana-server' do
   supports start: true, stop: true, restart: true, status: true, reload: false


### PR DESCRIPTION
In some cases we want to use our way of managing the package installation, for instance in our environment we mirror all external repos and have a small custom resource that lets other servers use these mirrored repos.

This pull gives a simple way to turn off the installation of grafana in this cookbook.
