### PR TITLE
change the state_attr to be just the name, as the others have gone away

### DIFF
--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,8 +1,7 @@
 actions :create, :update, :delete
 default_action :create
 
-state_attrs :login,
-  :admin
+state_attrs :name
 
 # Grafana options
 attribute :host, kind_of: String, default: 'localhost'


### PR DESCRIPTION
This fixes a bug whereby my `chef-client` run would successfully complete, but the report handlers would fail:

```
SNIP
[2015-12-08T16:24:32+00:00] INFO: Chef Run complete in 14.936654408 seconds

Running handlers:
[2015-12-08T16:24:32+00:00] INFO: Running report handlers
Running handlers complete
[2015-12-08T16:24:32+00:00] INFO: Report handlers complete

Deprecated features used!
SNIP DEPRECATION WARNINGS

Chef Client finished, 16/373 resources updated in 16 seconds

Running handlers:
[2015-12-08T16:24:32+00:00] ERROR: Running exception handlers
Running handlers complete
[2015-12-08T16:24:32+00:00] ERROR: Exception handlers complete
Chef Client failed. 16 resources updated in 16 seconds
[2015-12-08T16:24:32+00:00] ERROR: undefined method `login' for LWRP resource grafana_user from cookbook grafana
[2015-12-08T16:24:32+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

Suffice to say this had me scratching my head for a little while.
