### PR TITLE
There is an issue where new users are not given grafana admin options…

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -36,10 +36,15 @@ action :create do
     converge_by("Creating user #{new_resource.user[:login]}") do
       add_user(new_resource.user, grafana_options)
     end
+    new_users_list = get_user_list(grafana_options)
+    new_users_list.each do |n_user|
+      if n_user['login'] == new_resource.user[:login]
+        new_resource.user[:id] = n_user['id']
+      end
+    end
     converge_by("Setting permissions #{new_resource.user[:login]}") do
       update_user_permissions(new_resource.user, grafana_options)
     end
-
   end
 end
 


### PR DESCRIPTION
… when the action is create because "user[:id]" is not set until the user is created.. So this fix will create the user, then pull the user data and match the login names prior to updating the user permissions.

The update/create options on users, dashboards, datasources, orgs seem a little goofy to me.. seems like update should update or create if missing. or maybe cut it down to :run, :delete. and the run action will create/update it.
