### PR TITLE
Fix: change create_if_missing to create in organization

### DIFF
--- a/resources/organization.rb
+++ b/resources/organization.rb
@@ -1,5 +1,5 @@
 actions :create, :update, :delete
-default_action :create_if_missing
+default_action :create
 
 state_attrs :organization_name
 


### PR DESCRIPTION
Default action create_if_missing was removed but the default action didn't change.
