### PR TITLE
Return empty array when there's not org to list

### DIFF
--- a/libraries/organization_api.rb
+++ b/libraries/organization_api.rb
@@ -47,7 +47,7 @@ module GrafanaCookbook
 
       _do_request(grafana_options)
     rescue BackendError
-      nil
+      []
     end
 
     # Sets the current organization in context of grafana


### PR DESCRIPTION
Good practice says a function/method should always return the same type. In the case of an array we should always return a list. In this case, an empty list.
In this same repository, we use this method in the following places:
- https://github.com/JonathanTron/chef-grafana/blob/5e8f67448b0802451d05ea9ac1fd6da317cc9af4/providers/datasource.rb#L125
- https://github.com/JonathanTron/chef-grafana/blob/06174440ded35fec3c113137671cb1b5021547b0/providers/dashboard.rb#L135
- https://github.com/JonathanTron/chef-grafana/blob/5e8f67448b0802451d05ea9ac1fd6da317cc9af4/providers/organization.rb#L24
- https://github.com/JonathanTron/chef-grafana/blob/5e8f67448b0802451d05ea9ac1fd6da317cc9af4/providers/organization.rb#L52
- https://github.com/JonathanTron/chef-grafana/blob/5e8f67448b0802451d05ea9ac1fd6da317cc9af4/providers/organization.rb#L87

In all following lines/methods they expect an array (even an empty one) and not a nil value.
