### PR TITLE
functionality to add user to organizations when adding or updating Grafana users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,10 +20,13 @@ Metrics/MethodLength:
   Max: 30
 
 Metrics/ModuleLength:
-  Max: 120
+  Max: 170
+
+CyclomaticComplexity:
+  Max: 8
 
 Metrics/PerceivedComplexity:
-  Max: 8
+  Max: 9
 
 Style/AsciiComments:
   Enabled: false

--- a/libraries/organization_api.rb
+++ b/libraries/organization_api.rb
@@ -3,6 +3,102 @@ module GrafanaCookbook
     include GrafanaCookbook::ApiHelper
 
     #
+    def add_user_to_orgs(user, grafana_options)
+      orgs = get_orgs_list(grafana_options)
+      selected_orgs = user[:organizations].map { |user_org| orgs.detect { |org| org['name'] == user_org[:name] } }
+
+      unless selected_orgs
+        raise "Could not find any of the #{user[:organizations].map { |user_org| user_org[:name] }} organizations"
+      end
+
+      selected_orgs.each do |selected_org|
+        select_org(selected_org, grafana_options)
+        add_user_to_org(user, grafana_options, selected_org)
+      end
+    rescue BackendError
+      nil
+    end
+
+    def add_user_to_org(user, grafana_options, organization)
+      grafana_options[:method] = 'Post'
+      grafana_options[:success_msg] = 'The user has been successfully added to organization.'
+      grafana_options[:unknown_code_msg] = 'OrganizationApi::add_user_to_org unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/org/users'
+      grafana_options[:accept_header] = 'application/json;charset=utf-8;'
+
+      user_role = user[:organizations].detect { |user_org| user_org[:name] == organization['name'] }[:role]
+      payload = { 'role' => user_role, 'loginOrEmail' => user[:login] }
+      _do_request(grafana_options, payload.to_json)
+    rescue BackendError
+      nil
+    end
+
+    def update_user_orgs(user, grafana_options)
+      orgs = get_orgs_list(grafana_options)
+      selected_orgs = user[:organizations].map { |user_org| orgs.detect { |org| org['name'] == user_org[:name] } }
+
+      unless selected_orgs
+        raise "Could not find any of the #{user[:organizations].map { |user_org| user_org[:name] }} organizations"
+      end
+
+      selected_orgs.each do |selected_org|
+        select_org(selected_org, grafana_options)
+        users_list = get_org_users(grafana_options)
+        exists = false
+        current_role = nil
+        # check if user exist in the organization
+        users_list.each do |user_|
+          if user_['login'] == user[:login]
+            exists = true
+            current_role = user_['role']
+          end
+          break if exists
+        end
+
+        # add user to org if not exist
+        unless exists
+          add_user_to_org(user, grafana_options, selected_org)
+          next
+        end
+
+        new_role = user[:organizations].detect { |user_org| user_org[:name] == selected_org['name'] }[:role]
+        if new_role == 'DELETE'
+          # if user role is set to delete, delete the user from the organization
+          delete_user_from_org(user, grafana_options)
+        elsif new_role != current_role
+          update_user_org(user, grafana_options, new_role)
+        end
+      end
+    rescue BackendError
+      nil
+    end
+
+    def update_user_org(user, grafana_options, role)
+      grafana_options[:method] = 'Patch'
+      grafana_options[:success_msg] = 'The user organization has been successfully updated.'
+      grafana_options[:unknown_code_msg] = 'OrganizationApi::update_user_org unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/org/users/' + user[:id].to_s
+      grafana_options[:accept_header] = 'application/json;charset=utf-8;'
+
+      payload = { 'role' => role }
+      _do_request(grafana_options, payload.to_json)
+    rescue BackendError
+      nil
+    end
+
+    def delete_user_from_org(user, grafana_options)
+      grafana_options[:method] = 'Delete'
+      grafana_options[:success_msg] = 'The user organization has been successfully deleted.'
+      grafana_options[:unknown_code_msg] = 'OrganizationApi::delete_user_from_org unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/org/users/' + user[:id].to_s
+      grafana_options[:accept_header] = 'application/json;charset=utf-8;'
+
+      _do_request(grafana_options)
+    rescue BackendError
+      nil
+    end
+
+    #
     def add_org(organization, grafana_options)
       grafana_options[:method] = 'Post'
       grafana_options[:success_msg] = 'Organization addition was successful.'
@@ -50,6 +146,17 @@ module GrafanaCookbook
       []
     end
 
+    def get_org_users(grafana_options)
+      grafana_options[:method] = 'Get'
+      grafana_options[:success_msg] = 'The list of organization users has been successfully retrieved.'
+      grafana_options[:unknown_code_msg] = 'OrganizationApi::get_org_users unchecked response code: %{code}'
+      grafana_options[:endpoint] = '/api/org/users'
+
+      _do_request(grafana_options)
+    rescue BackendError
+      []
+    end
+
     # Sets the current organization in context of grafana
     def select_org(organization, grafana_options)
       grafana_options[:method] = 'Post'
@@ -72,6 +179,8 @@ module GrafanaCookbook
                   Net::HTTP::Put.new(grafana_options[:endpoint])
                 when 'Delete'
                   Net::HTTP::Delete.new(grafana_options[:endpoint])
+                when 'Patch'
+                  Net::HTTP::Patch.new(grafana_options[:endpoint])
                 else
                   Net::HTTP::Get.new(grafana_options[:endpoint])
                 end


### PR DESCRIPTION
Please review.

Ex. 1: add j.smith to 'Org. 1' as Admin and to 'Org. 2' as Viewer

```
grafana_user 'j.smith' do
  user(
    name: 'John Smith',
    email: 'test@example.com',
    password: 'test123',
    isAdmin: true,
    organizations: [
      { name: 'Org. 1', role: 'Admin' },
      { name: 'Org. 2', role: 'Viewer' }
    ]
  )
  action :create
end
```

Ex. 2: change j.smith role in Org. 2 to Admin

```
grafana_user 'j.smith' do
  user(
    organizations: [
      { name: 'Org. 2', role: 'Admin' }
    ]
  )
  action :update
end
```

Ex. 3: remove j.smith from Org. 2

```
grafana_user 'j.smith' do
  user(
    organizations: [
      { name: 'Org. 2', role: 'DELETE' }
    ]
  )
  action :update
end
```

Ex. 4: add j.smith back to Org. 2 as Viewer

```
grafana_user 'j.smith' do
  user(
    organizations: [
      { name: 'Org. 2', role: 'Viewer' }
    ]
  )
  action :update
end
```

also fixed issue with user update unchecking isAdmin when isAdmin sub-attribute is not specified in the user attribute.

Thanks 
