### PR TITLE
Update gpg key location for rhel/fedora

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,7 +33,7 @@ when 'debian'
   default['grafana']['package']['apt_rebuild'] = false
 when 'rhel', 'fedora'
   default['grafana']['package']['repo'] = 'https://packagecloud.io/grafana/stable/el/$releasever/$basearch'
-  default['grafana']['package']['key'] = 'https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana'
+  default['grafana']['package']['key'] = 'https://packagecloud.io/grafana/stable/gpgkey'
   default['grafana']['package']['version'] = "#{node['grafana']['version']}-1"
 end
 


### PR DESCRIPTION
Fixes #139 

While the [Grafana site](http://docs.grafana.org/installation/rpm/#rpm-gpg-key) says the key to use is `https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana`, and that may work, the yum repository installation instructions for Grafana at `packagecloud.io` (where we're getting the package), says to use `https://packagecloud.io/grafana/stable/gpgkey`

This change sets the key url to be the latter
