### PR TITLE
Fixed install from file versioning for grafana v3.0.1 and above

### DIFF
--- a/recipes/_install_file.rb
+++ b/recipes/_install_file.rb
@@ -50,8 +50,12 @@ when 'rhel'
 
   grafana_installed = "yum list installed | grep grafana | grep #{node['grafana']['version']}"
 
+  # NOTE: after v3.0.1 the rpm pkg names no longer only contain a "-1" but a build
+  # number like this: "grafana-3.0.2-1463043100.x86_64.rpm"
+  release = node['grafana']['version'] <= '3.0.1' ? '-1' : ''
+
   remote_file "#{Chef::Config[:file_cache_path]}/grafana-#{node['grafana']['version']}.rpm" do
-    source "#{node['grafana']['file']['url']}-#{node['grafana']['version']}-1.x86_64.rpm"
+    source "#{node['grafana']['file']['url']}-#{node['grafana']['version']}#{release}.x86_64.rpm"
     checksum node['grafana']['file']['checksum']['rpm']
     action :create
     not_if grafana_installed


### PR DESCRIPTION
## Bug

Installing any version above `v3.0.1` with the `file` method is not possible on RHEL family platforms.

After `v3.0.1` the rpm package names on S3 no longer only contain a `-1` as the release number but a full build number like this: `grafana-3.0.2-1463043100.x86_64.rpm`
## Solution

Add conditional code to handle this diversion by not inserting the `-1` if installing version `v3.0.1` or below.

The build number must be inserted into the Chef attribute (needed for deb and rpm packages):

``` ruby
default["grafana"]["version"] = "3.0.4-1464167696"
```
