### PR TITLE
Enables to install Grafana 3 using file installer

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ when 'debian'
   default['grafana']['package']['apt_rebuild'] = false
   default['grafana']['package']['trusted'] = false
 when 'rhel', 'fedora'
+  default['grafana']['file']['release_id'] = '-1'
   default['grafana']['package']['repo'] = 'https://packagecloud.io/grafana/stable/el/$releasever/$basearch'
   default['grafana']['package']['key'] = 'https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana'
   default['grafana']['package']['version'] = "#{node['grafana']['version']}-1"

--- a/recipes/_install_file.rb
+++ b/recipes/_install_file.rb
@@ -29,7 +29,7 @@ when 'debian'
   grafana_installed = "dpkg -l | grep '^ii' | grep grafana | grep #{node['grafana']['version']}"
 
   remote_file "#{Chef::Config[:file_cache_path]}/grafana-#{node['grafana']['version']}.deb" do
-    source "#{node['grafana']['file']['url']}_#{node['grafana']['version']}_amd64.deb"
+    source "#{node['grafana']['file']['url']}_#{node['grafana']['version']}#{node['grafana']['release_id']}_amd64.deb"
     checksum node['grafana']['file']['checksum']['deb']
     action :create
     not_if grafana_installed
@@ -51,7 +51,7 @@ when 'rhel'
   grafana_installed = "yum list installed | grep grafana | grep #{node['grafana']['version']}"
 
   remote_file "#{Chef::Config[:file_cache_path]}/grafana-#{node['grafana']['version']}.rpm" do
-    source "#{node['grafana']['file']['url']}-#{node['grafana']['version']}-1.x86_64.rpm"
+    source "#{node['grafana']['file']['url']}-#{node['grafana']['version']}#{node['grafana']['release_id']}.x86_64.rpm"
     checksum node['grafana']['file']['checksum']['rpm']
     action :create
     not_if grafana_installed

--- a/recipes/_install_file.rb
+++ b/recipes/_install_file.rb
@@ -29,7 +29,7 @@ when 'debian'
   grafana_installed = "dpkg -l | grep '^ii' | grep grafana | grep #{node['grafana']['version']}"
 
   remote_file "#{Chef::Config[:file_cache_path]}/grafana-#{node['grafana']['version']}.deb" do
-    source "#{node['grafana']['file']['url']}_#{node['grafana']['version']}#{node['grafana']['release_id']}_amd64.deb"
+    source "#{node['grafana']['file']['url']}_#{node['grafana']['version']}#{node['grafana']['file']['release_id']}_amd64.deb"
     checksum node['grafana']['file']['checksum']['deb']
     action :create
     not_if grafana_installed
@@ -51,7 +51,7 @@ when 'rhel'
   grafana_installed = "yum list installed | grep grafana | grep #{node['grafana']['version']}"
 
   remote_file "#{Chef::Config[:file_cache_path]}/grafana-#{node['grafana']['version']}.rpm" do
-    source "#{node['grafana']['file']['url']}-#{node['grafana']['version']}#{node['grafana']['release_id']}.x86_64.rpm"
+    source "#{node['grafana']['file']['url']}-#{node['grafana']['version']}#{node['grafana']['file']['release_id']}.x86_64.rpm"
     checksum node['grafana']['file']['checksum']['rpm']
     action :create
     not_if grafana_installed


### PR DESCRIPTION
Grafana 3 rpm and deb file installers have a release identification string. In the file recipe, we have hardcoded 1 for rpm and none for deb installer of Grafana 2. This change to use attribute for that part will allow any wrapper cookbook to install grafana 3 using file installer by specifying version, checksum and release id.
