### PR TITLE
Add exception handling for JSON::ParserError

### DIFF
--- a/libraries/api_helper.rb
+++ b/libraries/api_helper.rb
@@ -87,7 +87,11 @@ module GrafanaCookbook
         success: grafana_options[:success_msg],
         unknown_code: grafana_options[:unknown_code_msg]
       )
-      JSON.parse(response.body)
+      begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        nil
+      end
     rescue BackendError
       nil
     end


### PR DESCRIPTION
Add exception handling for JSON::ParserError. Without this exception handling, error is returned on updating resources:

```       ================================================================================
           Error executing action `update` on resource 'grafana_datasource[prometheus]'
           ================================================================================

           JSON::ParserError
           -----------------
           784: unexpected token at '<*api.NormalResponse Value>'
```
After this, everything is fine, all resources including `grafana_datasource`, `grafana_user`, `grafana_dashboard`, `grafana_organization` are working properly as expected.

In addition replacing proper property name for reporting: https://github.com/JonathanTron/chef-grafana/issues/156