### PR TITLE
no use "-1" to construct version number for rhel rpm packaging

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,7 +35,7 @@ when 'debian'
 when 'rhel', 'fedora'
   default['grafana']['package']['repo'] = 'https://packagecloud.io/grafana/stable/el/$releasever/$basearch'
   default['grafana']['package']['key'] = 'https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana'
-  default['grafana']['package']['version'] = "#{node['grafana']['version']}-1"
+  default['grafana']['package']['version'] = get_rpm_version(node['grafana']['version'])
   default['grafana']['package']['checkkey'] = true
 end
 

--- a/libraries/install_helper.rb
+++ b/libraries/install_helper.rb
@@ -1,0 +1,5 @@
+
+def get_rpm_version(version)
+  return "#{version}-1" if Gem::Version.new(version) <= Gem::Version.new('3.0.1')
+  version
+end

--- a/recipes/_install_file.rb
+++ b/recipes/_install_file.rb
@@ -48,17 +48,18 @@ when 'rhel'
     package pkg
   end
 
+  rpm_version = get_rpm_version(node['grafana']['version'])
   grafana_installed = "yum list installed | grep grafana | grep #{node['grafana']['version']}"
 
-  remote_file "#{Chef::Config[:file_cache_path]}/grafana-#{node['grafana']['version']}.rpm" do
-    source "#{node['grafana']['file']['url']}-#{node['grafana']['version']}-1.x86_64.rpm"
+  remote_file "#{Chef::Config[:file_cache_path]}/grafana-#{rpm_version}.rpm" do
+    source "#{node['grafana']['file']['url']}-#{rpm_version}.x86_64.rpm"
     checksum node['grafana']['file']['checksum']['rpm']
     action :create
     not_if grafana_installed
   end
 
   rpm_package "grafana-#{node['grafana']['version']}" do
-    source "#{Chef::Config[:file_cache_path]}/grafana-#{node['grafana']['version']}.rpm"
+    source "#{Chef::Config[:file_cache_path]}/grafana-#{rpm_version}.rpm"
     version node['grafana']['version']
     action :install
     not_if grafana_installed


### PR DESCRIPTION
Now grafana provides official rpm package and it doesn't have "-1" as version number, like *grafana-4.0.2-1481203731.x86_64.rpm* . I think we don't need to use such a substring.

* http://docs.grafana.org/installation/rpm/
