### PR TITLE
Update download URL

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: vagrant
-  require_chef_omnibus: '12.3.0'
+  require_chef_omnibus: '12.19.36'
   customize:
     memory: 1024
     cpus: 2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,5 +52,8 @@ Style/SignalException:
 Style/FormatString:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
 RegexpLiteral:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,9 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Max: 170
 
+Metrics/BlockLength:
+  Max: 250
+
 CyclomaticComplexity:
   Max: 8
 
@@ -44,4 +47,10 @@ Style/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 
 Style/SignalException:
+  Enabled: false
+
+Style/FormatString:
+  Enabled: false
+
+RegexpLiteral:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 sudo: false
 bundler_args: --without integration --path=$PWD/vendor/bundle
 rvm:
-  - 2.3
+  - 2.3.4
 before_script:
   - bundle exec berks vendor vendor/cookbooks
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf', '~> 4.0'
-gem 'rake'
 gem 'emeril'
+gem 'rake'
 
 group :test do
   gem 'chefspec', '~> 4.4.0'
@@ -11,14 +11,14 @@ group :test do
 end
 
 group :integration do
-  gem 'test-kitchen'
   gem 'kitchen-vagrant'
+  gem 'test-kitchen'
 end
 
 group :development do
-  gem 'rb-readline'
   gem 'guard'
   gem 'guard-foodcritic'
   gem 'guard-rspec'
   gem 'guard-rubocop'
+  gem 'rb-readline'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,11 +17,11 @@
 
 default['grafana']['manage_install'] = true
 default['grafana']['install_type'] = 'file' # file | package | source
-default['grafana']['version'] = '2.1.2'
+default['grafana']['version'] = '4.2.0'
 
-default['grafana']['file']['url'] = 'https://grafanarel.s3.amazonaws.com/builds/grafana'
-default['grafana']['file']['checksum']['deb'] = '57f52cc8e510f395f7f15caac841dc31e67527072fcbf5cc2d8351404989b298'
-default['grafana']['file']['checksum']['rpm'] = '618f5361e594b101a4832a67a9d82f1179c35ff158ef4288dc1f8b6e8de67bb8'
+default['grafana']['file']['url'] = 'https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana'
+default['grafana']['file']['checksum']['deb'] = 'ab6dd9406fb6f7a807d220e1bdd9f472fad580c51fd84bcd732342dac08ad341'
+default['grafana']['file']['checksum']['rpm'] = 'b7ba83dd4ec2d31080c95d6530bffdc900aee2b1cc7ee6d125a04b979e850d76'
 
 case node['platform_family']
 when 'debian'

--- a/libraries/api_helper.rb
+++ b/libraries/api_helper.rb
@@ -44,7 +44,7 @@ module GrafanaCookbook
       wait_time = opts.fetch :wait_time, 2
       exceptions = Array(opts.fetch(:exceptions))
 
-      return if tries == 0
+      return if tries.zero?
 
       begin
         yield

--- a/libraries/organization_api.rb
+++ b/libraries/organization_api.rb
@@ -168,6 +168,5 @@ module GrafanaCookbook
     rescue BackendError
       nil
     end
-
   end
 end

--- a/recipes/_nginx.rb
+++ b/recipes/_nginx.rb
@@ -36,4 +36,4 @@ template '/etc/nginx/sites-available/grafana' do
   notifies :reload, 'service[nginx]', :immediately
 end
 
-nginx_site 'grafana' 
+nginx_site 'grafana'


### PR DESCRIPTION
Grafana downloads moved to a new URL. Also install 4.2.0 by default and test with newer chef-client. Also resolve rubocop issues.