### PR TITLE
Supports pid dir attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,6 +52,7 @@ when 'rhel', 'fedora'
   default['grafana']['env_dir'] = '/etc/sysconfig'
 end
 default['grafana']['conf_dir'] = '/etc/grafana'
+default['grafana']['pid_dir'] = '/var/run/grafana/'
 
 ## ini file configuration
 # format is the following [section][key] = value

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -51,6 +51,13 @@ directory node['grafana']['log_dir'] do
   action :create
 end
 
+directory node['grafana']['pid_dir'] do
+  owner node['grafana']['user']
+  group node['grafana']['group']
+  mode '0755'
+  action :create
+end
+
 g_default_template = template '/etc/default/grafana-server' do
   source 'grafana-env.erb'
   variables(
@@ -60,6 +67,7 @@ g_default_template = template '/etc/default/grafana-server' do
     log_dir: node['grafana']['log_dir'],
     data_dir: node['grafana']['data_dir'],
     conf_dir: node['grafana']['conf_dir'],
+    pid_dir: node['grafana']['pid_dir'],
     plugins_dir: node['grafana']['plugins_dir']
   )
   owner 'root'

--- a/templates/default/grafana-env.erb
+++ b/templates/default/grafana-env.erb
@@ -11,4 +11,5 @@ PLUGINS_DIR=<%= @plugins_dir %>
 MAX_OPEN_FILES=10000
 CONF_DIR=<%= @conf_dir %>
 CONF_FILE=<%= @conf_dir %>/grafana.ini
+PID_FILE_DIR=<%= @pid_dir %>
 RESTART_ON_UPGRADE=false


### PR DESCRIPTION
hi!
In 4.6.1 it seems necessary to specify pid dir at startup, so we responded

```
# cat /usr/lib/systemd/system/grafana-server.service
[Unit]
Description=Grafana instance
Documentation=http://docs.grafana.org
Wants=network-online.target
After=network-online.target
After=postgresql.service mariadb.service mysql.service

[Service]
EnvironmentFile=/etc/default/grafana-server
User=grafana
Group=grafana
Type=simple
Restart=on-failure
WorkingDirectory=/usr/share/grafana
RuntimeDirectory=grafana
RuntimeDirectoryMode=0750
ExecStart=/usr/sbin/grafana-server                                        \
                            --config=${CONF_FILE}                         \
                            --pidfile=${PID_FILE_DIR}/grafana-server.pid  \ ★
                            cfg:default.paths.logs=${LOG_DIR}             \
                            cfg:default.paths.data=${DATA_DIR}            \
                            cfg:default.paths.plugins=${PLUGINS_DIR}
LimitNOFILE=10000
TimeoutStopSec=20
UMask=0027

[Install]
WantedBy=multi-user.target
```