### PR TITLE
Replace chef_nginx by nginx

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,6 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'chef_nginx'
 cookbook 'git'
 cookbook 'java'
 cookbook 'build-essential'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you would like to configure pre-2.0 versions of Grafana, please use the 1.x b
 
 * [apt](https://supermarket.chef.io/cookbooks/apt)
 * [yum](https://supermarket.chef.io/cookbooks/yum)
-* [chef_nginx](https://supermarket.chef.io/cookbooks/chef_nginx)
+* [nginx](https://supermarket.chef.io/cookbooks/nginx)
 
 ## Recipes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,4 +18,4 @@ recipe 'grafana::default', 'Installs and configures Grafana with a web server pr
 
 depends 'apt'
 depends 'yum'
-depends 'chef_nginx'
+depends 'nginx'

--- a/recipes/_nginx.rb
+++ b/recipes/_nginx.rb
@@ -21,7 +21,7 @@
 node.default['nginx']['repo_source'] = 'nginx'
 node.default['nginx']['default_site_enabled'] = false
 node.default['nginx']['server_tokens'] = 'off'
-include_recipe 'chef_nginx'
+include_recipe 'nginx'
 
 template '/etc/nginx/sites-available/grafana' do
   source node['grafana']['nginx']['template']


### PR DESCRIPTION
Chef has took over nginx cookbook which is now the official cookbook.
Keeping chef_nginx add a constraint on the Ohai cookbook at version 3.

This commit replace all references to chef_nginx by nginx.
Also remove the reference in the Berksfile, because it's properly set
in the metadata.

Fix #184 

*Cc.* @aboten