### PR TITLE
use nginx_site to manage vhost, depend on nginx

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,7 @@ source 'https://supermarket.chef.io'
 
 metadata
 
+cookbook 'nginx'
 cookbook 'git'
 cookbook 'java'
 cookbook 'build-essential'

--- a/recipes/_nginx.rb
+++ b/recipes/_nginx.rb
@@ -23,13 +23,9 @@ node.default['nginx']['default_site_enabled'] = false
 node.default['nginx']['server_tokens'] = 'off'
 include_recipe 'nginx'
 
-template '/etc/nginx/sites-available/grafana' do
-  source node['grafana']['nginx']['template']
+nginx_site 'Grafana' do
+  template node['grafana']['nginx']['template']
   cookbook node['grafana']['nginx']['template_cookbook']
-  notifies :reload, 'service[nginx]'
-  mode '0644'
-  owner 'root'
-  group 'root'
   variables(
     grafana_port: node['grafana']['ini']['server']['http_port'] || 3000,
     server_name: node['grafana']['webserver_hostname'],
@@ -37,9 +33,5 @@ template '/etc/nginx/sites-available/grafana' do
     listen_address: node['grafana']['webserver_listen'],
     listen_port: node['grafana']['webserver_port']
   )
-  notifies :reload, 'service[nginx]', :immediately
-end
-
-nginx_site 'grafana' do
   action :enable
 end


### PR DESCRIPTION
[chef_nginx is deprecated](https://supermarket.chef.io/cookbooks/chef_nginx) and newer versions of common cookbooks are moving away from it.

To maintain compatibility going forward and simplify the dependency graph for nodes with complex run_lists, this PR moves to the new [nginx](https://supermarket.chef.io/cookbooks/nginx) cookbook.