### PR TITLE
chef-client 14 freezes the new_resource hash

### DIFF
--- a/libraries/dashboard_api.rb
+++ b/libraries/dashboard_api.rb
@@ -2,7 +2,6 @@ module GrafanaCookbook
   module DashboardApi
     include GrafanaCookbook::ApiHelper
 
-    #
     def create_update_dashboard(dashboard, grafana_options)
       # Find dashboard from file and build payload
       dashboard_source_file = find_dashboard_source_file dashboard
@@ -21,7 +20,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def delete_dashboard(dashboard, grafana_options)
       grafana_options[:method] = 'Delete'
       grafana_options[:success_msg] = 'Dashboard deletion was successful.'

--- a/libraries/organization_api.rb
+++ b/libraries/organization_api.rb
@@ -2,7 +2,6 @@ module GrafanaCookbook
   module OrganizationApi
     include GrafanaCookbook::ApiHelper
 
-    #
     def add_user_to_orgs(user, grafana_options)
       orgs = get_orgs_list(grafana_options)
       selected_orgs = user[:organizations].map { |user_org| orgs.detect { |org| org['name'] == user_org[:name] } }
@@ -98,7 +97,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def add_org(organization, grafana_options)
       grafana_options[:method] = 'Post'
       grafana_options[:success_msg] = 'Organization addition was successful.'
@@ -110,7 +108,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def update_org(organization, grafana_options)
       grafana_options[:method] = 'Put'
       grafana_options[:success_msg] = 'Organization update was successful.'
@@ -122,7 +119,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def delete_org(organization, grafana_options)
       grafana_options[:method] = 'Delete'
       grafana_options[:success_msg] = 'Organization deletion was successful.'

--- a/providers/dashboard.rb
+++ b/providers/dashboard.rb
@@ -56,9 +56,6 @@ action :update do
 
   dashboard_sanity(new_dashboard)
 
-  # Find wether dashboard already exists
-  dash = get_dashboard(new_dashboard, grafana_options)
-
   converge_by("Updating dashboard #{new_resource.name}") do
     create_update_dashboard(new_dashboard, grafana_options)
   end

--- a/providers/dashboard.rb
+++ b/providers/dashboard.rb
@@ -10,39 +10,40 @@ action :create do
     user: new_resource.admin_user,
     password: new_resource.admin_password,
   }
-  # If dashboard's name is not provided as variable,
+  # If dashboard's name, source, or cookbook is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.dashboard.key?(:name)
-    new_resource.dashboard[:name] = new_resource.name
-  end
+  new_dashboard = {
+    name: new_resource.name,
+    source: new_resource.name,
+    cookbook: cookbook_name,
+  }
+  new_dashboard.merge!(new_resource.dashboard)
 
   _select_org(new_resource, grafana_options)
 
-  # If dashboard source is not provided as variable,
-  # Let's use resource name for it
-  unless new_resource.dashboard.key?(:source)
-    new_resource.dashboard[:source] = new_resource.name
-  end
-  # If dashboard cookbook is not provided as variable,
-  # Let's use resource name for it
-  unless new_resource.dashboard.key?(:cookbook)
-    new_resource.dashboard[:cookbook] = cookbook_name
-  end
-  dashboard_sanity(new_resource.dashboard)
+  dashboard_sanity(new_dashboard)
 
   # Find wether dashboard already exists
-  dash = get_dashboard(new_resource.dashboard, grafana_options)
+  dash = get_dashboard(new_dashboard, grafana_options)
 
   # If not found, or if overwrite is set to true, let's create it
-  if dash.nil? || new_resource.dashboard[:overwrite]
+  if dash.nil? || new_dashboard[:overwrite]
     converge_by("Creating dashboard #{new_resource.name}") do
-      create_update_dashboard(new_resource.dashboard, grafana_options)
+      create_update_dashboard(new_dashboard, grafana_options)
     end
   end
 end
 
 action :update do
-  new_resource.dashboard[:overwrite] = true
+  # If dashboard's name, source, or cookbook is not provided as variable,
+  # Let's use resource name for it
+  new_dashboard = {
+    name: new_resource.name,
+    source: new_resource.name,
+    cookbook: cookbook_name,
+  }
+  new_dashboard.merge!(new_resource.dashboard)
+  new_dashboard[:overwrite] = true
 
   grafana_options = {
     host: new_resource.host,
@@ -50,34 +51,16 @@ action :update do
     user: new_resource.admin_user,
     password: new_resource.admin_password,
   }
-  # If dashboard's name is not provided as variable,
-  # Let's use resource name for it
-  unless new_resource.dashboard.key?(:name)
-    new_resource.dashboard[:name] = new_resource.name
-  end
 
   _select_org(new_resource, grafana_options)
 
-  # If dashboard source is not provided as variable,
-  # Let's use resource name for it
-  unless new_resource.dashboard.key?(:source)
-    new_resource.dashboard[:source] = new_resource.name
-  end
-  # If dashboard cookbook is not provided as variable,
-  # Let's use resource name for it
-  unless new_resource.dashboard.key?(:cookbook)
-    new_resource.dashboard[:cookbook] = cookbook_name
-  end
-  dashboard_sanity(new_resource.dashboard)
+  dashboard_sanity(new_dashboard)
 
   # Find wether dashboard already exists
-  dash = get_dashboard(new_resource.dashboard, grafana_options)
+  dash = get_dashboard(new_dashboard, grafana_options)
 
-  # If not found, or if overwrite is set to true, let's update it
-  if dash.nil? || new_resource.dashboard[:overwrite]
-    converge_by("Updating dashboard #{new_resource.name}") do
-      create_update_dashboard(new_resource.dashboard, grafana_options)
-    end
+  converge_by("Updating dashboard #{new_resource.name}") do
+    create_update_dashboard(new_dashboard, grafana_options)
   end
 end
 
@@ -88,33 +71,26 @@ action :delete do
     user: new_resource.admin_user,
     password: new_resource.admin_password,
   }
-  # If dashboard's name is not provided as variable,
+  # If dashboard's name, source, or cookbook is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.dashboard.key?(:name)
-    new_resource.dashboard[:name] = new_resource.name
-  end
+  new_dashboard = {
+    name: new_resource.name,
+    source: new_resource.name,
+    cookbook: cookbook_name,
+  }
+  new_dashboard.merge!(new_resource.dashboard)
 
   _select_org(new_resource, grafana_options)
 
-  # If dashboard source is not provided as variable,
-  # Let's use resource name for it
-  unless new_resource.dashboard.key?(:source)
-    new_resource.dashboard[:source] = new_resource.name
-  end
-  # If dashboard cookbook is not provided as variable,
-  # Let's use resource name for it
-  unless new_resource.dashboard.key?(:cookbook)
-    new_resource.dashboard[:cookbook] = cookbook_name
-  end
   dashboard_sanity(new_resource.dashboard)
 
   # Find wether dashboard already exists
-  dash = get_dashboard(new_resource.dashboard, grafana_options)
+  dash = get_dashboard(new_dashboard, grafana_options)
 
   # If found, just delete it
   unless dash.nil?
     converge_by("Removing dashboard #{new_resource.name}") do
-      delete_dashboard(new_resource.dashboard, grafana_options)
+      delete_dashboard(new_dashboard, grafana_options)
     end
   end
 end

--- a/providers/datasource.rb
+++ b/providers/datasource.rb
@@ -12,9 +12,8 @@ action :create do
   }
   # If datasource name is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.datasource.key?(:name)
-    new_resource.datasource[:name] = new_resource.name
-  end
+  new_datasource = { name: new_resource.name }
+  new_datasource.merge!(new_resource.datasource)
 
   _select_org(new_resource, grafana_options)
 
@@ -22,14 +21,14 @@ action :create do
   exists = false
 
   datasources.each do |src|
-    exists = true if src['name'] == new_resource.datasource[:name]
+    exists = true if src['name'] == new_datasource[:name]
     break if exists
   end
 
   # If not found, let's create it
   unless exists
-    converge_by("Creating datasource #{new_resource.datasource[:organization]} #{new_resource.datasource[:name]}") do
-      add_datasource(new_resource.datasource, _legacy_http_semantic, grafana_options)
+    converge_by("Creating datasource #{new_datasource[:organization]} #{new_datasource[:name]}") do
+      add_datasource(new_datasource, _legacy_http_semantic, grafana_options)
     end
   end
 end
@@ -43,9 +42,8 @@ action :update do
   }
   # If datasource name is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.datasource.key?(:name)
-    new_resource.datasource[:name] = new_resource.name
-  end
+  new_datasource = { name: new_resource.name }
+  new_datasource.merge!(new_resource.datasource)
 
   _select_org(new_resource, grafana_options)
 
@@ -53,10 +51,10 @@ action :update do
   exists = false
 
   # Check wether we have to update datasource's login
-  old_name = if new_resource.datasource[:name] != new_resource.name
+  old_name = if new_datasource[:name] != new_resource.name
                new_resource.name
              else
-               new_resource.datasource[:name]
+               new_datasource[:name]
              end
 
   # Find wether datasource already exists
@@ -64,9 +62,9 @@ action :update do
   datasources.each do |src|
     if src['name'] == old_name
       exists = true
-      new_resource.datasource[:id] = src['id']
-      converge_by("Updating datasource #{new_resource.datasource[:name]}") do
-        update_datasource(new_resource.datasource, _legacy_http_semantic, grafana_options)
+      new_datasource[:id] = src['id']
+      converge_by("Updating datasource #{new_datasource[:name]}") do
+        update_datasource(new_datasource, _legacy_http_semantic, grafana_options)
       end
     end
     break if exists
@@ -82,9 +80,8 @@ action :delete do
   }
   # If datasource name is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.datasource.key?(:name)
-    new_resource.datasource[:name] = new_resource.name
-  end
+  new_datasource = { name: new_resource.name }
+  new_datasource.merge!(new_resource.datasource)
 
   _select_org(new_resource, grafana_options)
 
@@ -94,11 +91,11 @@ action :delete do
   # Find wether datasource already exists
   # If found, delete it
   datasources.each do |src|
-    next unless src['name'] == new_resource.datasource[:name]
+    next unless src['name'] == new_datasource[:name]
     exists = true
-    new_resource.datasource[:id] = src['id']
+    new_datasource[:id] = src['id']
     converge_by("Deleting data source #{new_resource.name}") do
-      delete_datasource(new_resource.datasource, grafana_options)
+      delete_datasource(new_datasource, grafana_options)
     end
   end
 end

--- a/providers/organization.rb
+++ b/providers/organization.rb
@@ -11,21 +11,20 @@ action :create do
   }
   # If name is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.organization.key?(:name)
-    new_resource.organization[:name] = new_resource.name
-  end
+  new_organization = { name: new_resource.name }
+  new_organization.merge!(new_resource.organization)
 
   orgs = get_orgs_list(grafana_options)
   exists = false
 
   # Find wether organization already exists
   orgs.each do |org|
-    exists = true if org['name'] == new_resource.organization[:name]
+    exists = true if org['name'] == new_organization[:name]
     break if exists
   end
   unless exists
     converge_by("Creating organization #{new_resource.name}") do
-      add_org(new_resource.organization, grafana_options)
+      add_org(new_organization, grafana_options)
     end
   end
 end
@@ -39,26 +38,25 @@ action :update do
   }
   # If name is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.organization.key?(:name)
-    new_resource.organization[:name] = new_resource.name
-  end
+  new_organization = { name: new_resource.name }
+  new_organization.merge!(new_resource.organization)
 
   orgs = get_orgs_list(grafana_options)
   exists = false
 
   # Check wether we have to update user's login
-  old_login = if new_resource.organization[:name] != new_resource.name
+  old_login = if new_organization[:name] != new_resource.name
                 new_resource.name
               else
-                new_resource.organization[:name]
+                new_organization[:name]
               end
 
   orgs.each do |org|
     if org['name'] == old_login
       exists = true
-      new_resource.organization[:id] = org['id']
+      new_organization[:id] = org['id']
       converge_by("Updating organization #{new_resource.name}") do
-        update_org(new_resource.organization, grafana_options)
+        update_org(new_organization, grafana_options)
       end
     end
     break if exists
@@ -74,19 +72,18 @@ action :delete do
   }
   # If name is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.organization.key?(:name)
-    new_resource.organization[:name] = new_resource.name
-  end
+  new_organization = { name: new_resource.name }
+  new_organization.merge!(new_resource.organization)
 
   orgs = get_orgs_list(grafana_options)
   exists = false
 
   orgs.each do |org|
-    if org['name'] == new_resource.organization[:name]
+    if org['name'] == new_organization[:name]
       exists = true
-      new_resource.organization[:id] = org['id']
-      converge_by("Deleting organization #{new_resource.organization[:name]}") do
-        delete_org(new_resource.organization, grafana_options)
+      new_organization[:id] = org['id']
+      converge_by("Deleting organization #{new_organization[:name]}") do
+        delete_org(new_organization, grafana_options)
       end
     end
     break if exists

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -32,9 +32,7 @@ action :create do
     end
     new_users_list = get_user_list(grafana_options)
     new_users_list.each do |n_user|
-      if n_user['login'] == new_user[:login]
-        new_user[:id] = n_user['id']
-      end
+      n_user['login'] == new_user[:login] && new_user[:id] = n_user['id']
     end
     converge_by("Setting permissions #{new_user[:login]}") do
       update_user_permissions(new_user, grafana_options)

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -12,37 +12,36 @@ action :create do
   }
   # If login is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.user.key?(:login)
-    new_resource.user[:login] = new_resource.name
-  end
+  new_user = { login: new_resource.name }
+  new_user.merge!(new_resource.user)
 
   users_list = get_user_list(grafana_options)
   exists = false
 
   # Find wether user already exists
   users_list.each do |user|
-    exists = true if user['login'] == new_resource.user[:login]
+    exists = true if user['login'] == new_user[:login]
     break if exists
   end
 
   # If not found, let's create it and set its permissions
   unless exists
-    new_resource.user[:name] = new_resource.name
-    converge_by("Creating user #{new_resource.user[:login]}") do
-      add_user(new_resource.user, grafana_options)
+    new_user[:name] = new_resource.name
+    converge_by("Creating user #{new_user[:login]}") do
+      add_user(new_user, grafana_options)
     end
     new_users_list = get_user_list(grafana_options)
     new_users_list.each do |n_user|
-      if n_user['login'] == new_resource.user[:login]
-        new_resource.user[:id] = n_user['id']
+      if n_user['login'] == new_user[:login]
+        new_user[:id] = n_user['id']
       end
     end
-    converge_by("Setting permissions #{new_resource.user[:login]}") do
-      update_user_permissions(new_resource.user, grafana_options)
+    converge_by("Setting permissions #{new_user[:login]}") do
+      update_user_permissions(new_user, grafana_options)
     end
-    if new_resource.user.key?(:organizations)
-      converge_by("Adding user to organizations #{new_resource.user[:organizations].map { |org| org[:name] }}") do
-        add_user_to_orgs(new_resource.user, grafana_options)
+    if new_user.key?(:organizations)
+      converge_by("Adding user to organizations #{new_user[:organizations].map { |org| org[:name] }}") do
+        add_user_to_orgs(new_user, grafana_options)
       end
     end
   end
@@ -57,18 +56,17 @@ action :update do
   }
   # If login is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.user.key?(:login)
-    new_resource.user[:login] = new_resource.name
-  end
+  new_user = { login: new_resource.name }
+  new_user.merge!(new_resource.user)
 
   users_list = get_user_list(grafana_options)
   exists = false
 
   # Check wether we have to update user's login
-  old_login = if new_resource.user[:login] != new_resource.name
+  old_login = if new_user[:login] != new_resource.name
                 new_resource.name
               else
-                new_resource.user[:login]
+                new_user[:login]
               end
 
   # Find wether user already exists
@@ -76,21 +74,21 @@ action :update do
   users_list.each do |user|
     if user['login'] == old_login
       exists = true
-      new_resource.user[:id] = user['id']
-      converge_by("Updating details for user #{new_resource.user[:login]}") do
-        update_user_details(new_resource.user, grafana_options)
+      new_user[:id] = user['id']
+      converge_by("Updating details for user #{new_user[:login]}") do
+        update_user_details(new_user, grafana_options)
       end
-      converge_by("Updating password for user #{new_resource.user[:login]}") do
-        update_user_password(new_resource.user, grafana_options)
+      converge_by("Updating password for user #{new_user[:login]}") do
+        update_user_password(new_user, grafana_options)
       end
-      if new_resource.user[:isAdmin] != user['isAdmin'] && !new_resource.user[:isAdmin].nil?
-        converge_by("Updating permissions for user #{new_resource.user[:login]}") do
-          update_user_permissions(new_resource.user, grafana_options)
+      if new_user[:isAdmin] != user['isAdmin'] && !new_user[:isAdmin].nil?
+        converge_by("Updating permissions for user #{new_user[:login]}") do
+          update_user_permissions(new_user, grafana_options)
         end
       end
-      if new_resource.user.key?(:organizations)
-        converge_by("Updating user organizations #{new_resource.user[:organizations].map { |org| org[:name] }}") do
-          update_user_orgs(new_resource.user, grafana_options)
+      if new_user.key?(:organizations)
+        converge_by("Updating user organizations #{new_user[:organizations].map { |org| org[:name] }}") do
+          update_user_orgs(new_user, grafana_options)
         end
       end
     end
@@ -107,9 +105,8 @@ action :delete do
   }
   # If login is not provided as variable,
   # Let's use resource name for it
-  unless new_resource.user.key?(:login)
-    new_resource.user[:login] = new_resource.name
-  end
+  new_user = { login: new_resource.name }
+  new_user.merge!(new_resource.user)
 
   users_list = get_user_list(grafana_options)
   exists = false
@@ -117,12 +114,12 @@ action :delete do
   # Find wether use already exists
   # If found, just delete it
   users_list.each do |user|
-    if user['login'] == new_resource.user[:login]
+    if user['login'] == new_user[:login]
       exists = true
-      new_resource.user[:id] = user['id']
-      new_resource.user[:name] = new_resource.name
-      converge_by("Deleting user #{new_resource.user[:login]}") do
-        delete_user(new_resource.user, grafana_options)
+      new_user[:id] = user['id']
+      new_user[:name] = new_resource.name
+      converge_by("Deleting user #{new_user[:login]}") do
+        delete_user(new_user, grafana_options)
       end
     end
     break if exists


### PR DESCRIPTION
### Description

This fix makes the cookbook compatible with chef-client 14 (and maybe _more_ compatible with 13?). (Pretty sure it's related to [this chef 13 release note](https://docs.chef.io/release_notes.html#default-values-for-resource-properties-are-frozen) about the immutability of new_resource properties.

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md - this link should be updated to point to the [section in README.md](https://github.com/sous-chefs/grafana/#testing).
- [ ] ~~New functionality includes testing.~~ (not applicable)
- [ ] ~~New functionality has been documented in the README if applicable~~ (not applicable)

### Testing

Tests were performed using ChefDK 3.0.36. While I'm *mostly* confident my patch works, this [cookbook hasn't passed tests in ~3 months](https://travis-ci.org/sous-chefs/grafana/builds), and running kitchen-vagrant and kitchen-dokken tests on my own failed for different reasons, unrelated to my patch. I don't have the spare cycles to hunt it all down right now, so if someone beats me to the punch, I will happily re-base and test.

```
-- cookbooks/grafana ‹eschro/v3-chef-14› » chef --version
Chef Development Kit Version: 3.0.36
chef-client version: 14.1.12
delivery version: master (7206afaf4cf29a17d2144bb39c55b7212cfafcc7)
berks version: 7.0.2
kitchen version: 1.21.2
inspec version: 2.1.72
-- cookbooks/grafana ‹eschro/v3-chef-14› » foodcritic -X spec -f any ./
Checking 31 files
...............................

-- cookbooks/grafana ‹eschro/v3-chef-14› » rspec
...................................................................................................................WARNING: you must specify a 'platform' and 'version' to your ChefSpec Runner and/or Fauxhai constructor, in the future
omitting these will become a hard error. A list of available platforms is available at https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md
.

Finished in 18.7 seconds (files took 6.17 seconds to load)
116 examples, 0 failures

-- cookbooks/grafana ‹eschro/v3-chef-14› »
```
