### PR TITLE
Fix plugin chef13

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.chef.io'
 
 metadata
+group :integration do
+  cookbook 'apt'
+  cookbook 'curl'
+end

--- a/libraries/dashboard_api.rb
+++ b/libraries/dashboard_api.rb
@@ -2,7 +2,6 @@ module GrafanaCookbook
   module DashboardApi
     include GrafanaCookbook::ApiHelper
 
-    #
     def create_update_dashboard(dashboard, grafana_options)
       # Find dashboard from file and build payload
       dashboard_source_file = find_dashboard_source_file dashboard
@@ -21,7 +20,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def delete_dashboard(dashboard, grafana_options)
       grafana_options[:method] = 'Delete'
       grafana_options[:success_msg] = 'Dashboard deletion was successful.'

--- a/libraries/organization_api.rb
+++ b/libraries/organization_api.rb
@@ -2,7 +2,6 @@ module GrafanaCookbook
   module OrganizationApi
     include GrafanaCookbook::ApiHelper
 
-    #
     def add_user_to_orgs(user, grafana_options)
       orgs = get_orgs_list(grafana_options)
       selected_orgs = user[:organizations].map { |user_org| orgs.detect { |org| org['name'] == user_org[:name] } }
@@ -98,7 +97,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def add_org(organization, grafana_options)
       grafana_options[:method] = 'Post'
       grafana_options[:success_msg] = 'Organization addition was successful.'
@@ -110,7 +108,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def update_org(organization, grafana_options)
       grafana_options[:method] = 'Put'
       grafana_options[:success_msg] = 'Organization update was successful.'
@@ -122,7 +119,6 @@ module GrafanaCookbook
       nil
     end
 
-    #
     def delete_org(organization, grafana_options)
       grafana_options[:method] = 'Delete'
       grafana_options[:success_msg] = 'Organization deletion was successful.'

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -31,6 +31,6 @@ action :remove do
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::GrafanaPlugin.new(@new_resource.name)
+  @current_resource = Chef::Resource.resource_for_node(:grafana_plugin, node).new(@new_resource.name)
   @current_resource.installed = GrafanaCookbook::Plugin.installed?(new_resource.name, new_resource.grafana_cli_bin)
 end


### PR DESCRIPTION
### Description

Chef 13+ LWRPs need to load resources like:

```
Chef::Resource.resource_for_node(:resource_name, node).new(@new_resource.name)
```
rather than: 

```
Chef::Resource::ResourceName.new(@new_resource.name)
```

### Check List
- [X] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md
This file does not exist in this repo. I ran tests indicated at the end of the README. 
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
