### PR TITLE
Update to grafana 5.3.4

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -62,6 +62,13 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
+- name: ubuntu-18.04
+  driver:
+    image: dokken/ubuntu-18.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
 - name: opensuse-leap
   driver:
     image: dokken/opensuse-leap

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -48,13 +48,6 @@ platforms:
     image: dokken/fedora-27
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: ubuntu-14.04
-  driver:
-    image: dokken/ubuntu-14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-
 - name: ubuntu-16.04
   driver:
     image: dokken/ubuntu-16.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,13 +14,6 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-14.04
-    run_list:
-      - recipe[apt::default]
-      - recipe[curl::default]
-    attributes:
-      grafana:
-        webserver_listen: ''
   - name: ubuntu-16.04
     run_list:
       - recipe[apt::default]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,6 +28,13 @@ platforms:
     attributes:
       grafana:
         webserver_listen: ''
+  - name: ubuntu-18.04
+    run_list:
+      - recipe[apt::default]
+      - recipe[curl::default]
+    attributes:
+      grafana:
+        webserver_listen: ''
   - name: centos-6
     attributes:
       grafana:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 This file is used to list changes made in each version of grafana.
 
+## Unreleased
+- Update to Grafana 5.3.4
+- Drop support for Ubuntu 14.04
+- Add support for Ubuntu 18.04
+
 ## 3.0.1 (2018-11-12)
 - Add support for amazon. Chef 13 and later identifies platform_family as 'amazon': https://docs.chef.io/deprecations_ohai_amazon_linux.html
-
 
 ## 3.0.0 (2018-04-29)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you would like to configure pre-2.0 versions of Grafana, please use the 1.x b
 
 ### Platforms
 
-- Ubuntu >= 14.04
+- Ubuntu >= 16.04
 - Debian >= 8
 - CentOS/Redhat >= 6
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,11 +17,11 @@
 
 default['grafana']['manage_install'] = true
 default['grafana']['install_type'] = 'file' # file | package
-default['grafana']['version'] = '4.6.3'
+default['grafana']['version'] = '5.3.2'
 
 default['grafana']['file']['url'] = 'https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana'
-default['grafana']['file']['checksum']['deb'] = 'd022fceb939e7570d74b437932bee876e306b0e21ecdd830752c61b4e89dab31'
-default['grafana']['file']['checksum']['rpm'] = 'bfb639baffb34d43f826c6edc2912a8b79957ab08e777ec77fa7e931f741944c'
+default['grafana']['file']['checksum']['deb'] = 'e8d2369b3c541f181dd0d97d13704682161b4b831c3c0f0af08f8efbeb531a57'
+default['grafana']['file']['checksum']['rpm'] = 'd70f46120fae84b784a3857a677e8f26cf48a74b97b1a2c0c43de5c64f6158f7'
 
 case node['platform_family']
 when 'debian'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,11 +17,11 @@
 
 default['grafana']['manage_install'] = true
 default['grafana']['install_type'] = 'file' # file | package
-default['grafana']['version'] = '5.3.2'
+default['grafana']['version'] = '5.3.4'
 
 default['grafana']['file']['url'] = 'https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana'
-default['grafana']['file']['checksum']['deb'] = 'e8d2369b3c541f181dd0d97d13704682161b4b831c3c0f0af08f8efbeb531a57'
-default['grafana']['file']['checksum']['rpm'] = 'd70f46120fae84b784a3857a677e8f26cf48a74b97b1a2c0c43de5c64f6158f7'
+default['grafana']['file']['checksum']['deb'] = '1f1f38c9827c48ce603a59a283607955c5e0e96951ce0d67ed02edf7581a0a93'
+default['grafana']['file']['checksum']['rpm'] = '375e85339782cee09066267e3a6cd279d5ff71ce6c90a4ebcb9bd1c91de1d5c0'
 
 case node['platform_family']
 when 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ issues_url       'https://github.com/sous-chefs/chef-grafana/issues'
 chef_version     '>= 13.0'
 version          '3.0.0'
 
-supports 'ubuntu', '>= 14.04'
+supports 'ubuntu', '>= 16.04'
 supports 'debian', '>= 8.0'
 supports 'centos', '>= 6.4'
 supports 'redhat', '>= 6.4'

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -6,7 +6,7 @@ describe 'grafana::default' do
       'versions' => ['8.10'],
     },
     'ubuntu' => {
-      'versions' => ['14.04', '16.04'],
+      'versions' => ['14.04', '16.04', '18.04'],
     },
     'centos' => {
       'versions' => ['6.9', '7.4.1708'],
@@ -21,7 +21,7 @@ describe 'grafana::default' do
     }
   end
 
-  let(:grafana_version) { '4.6.3' }
+  let(:grafana_version) { '5.3.2' }
 
   platforms.each do |ext_platform, value|
     value['versions'].each do |ext_version|

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -6,7 +6,7 @@ describe 'grafana::default' do
       'versions' => ['8.10'],
     },
     'ubuntu' => {
-      'versions' => ['14.04', '16.04', '18.04'],
+      'versions' => ['16.04', '18.04'],
     },
     'centos' => {
       'versions' => ['6.9', '7.4.1708'],
@@ -21,7 +21,7 @@ describe 'grafana::default' do
     }
   end
 
-  let(:grafana_version) { '5.3.2' }
+  let(:grafana_version) { '5.3.4' }
 
   platforms.each do |ext_platform, value|
     value['versions'].each do |ext_version|

--- a/spec/unit/install_package_spec.rb
+++ b/spec/unit/install_package_spec.rb
@@ -6,7 +6,7 @@ describe 'grafana::_install_package' do
       'versions' => ['8.10'],
     },
     'ubuntu' => {
-      'versions' => ['14.04', '16.04', '18.04'],
+      'versions' => ['16.04', '18.04'],
     },
     'centos' => {
       'versions' => ['6.9', '7.4.1708'],

--- a/spec/unit/install_package_spec.rb
+++ b/spec/unit/install_package_spec.rb
@@ -6,7 +6,7 @@ describe 'grafana::_install_package' do
       'versions' => ['8.10'],
     },
     'ubuntu' => {
-      'versions' => ['14.04', '16.04'],
+      'versions' => ['14.04', '16.04', '18.04'],
     },
     'centos' => {
       'versions' => ['6.9', '7.4.1708'],


### PR DESCRIPTION
Signed-off-by: Eric Heydrick <eheydrick@gmail.com>

### Description

Update to latest grafana release, 5.3.4. Also add testing on Ubuntu 18.04 and drop Ubuntu 14.04. All tests pass.

### Issues Resolved

None.

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
