### PR TITLE
add amazon for platform_family [enhancement]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 3.0.1 (2018-11-12)
+- Add support for amazon. Chef 13 and later identifies platform_family as 'amazon': https://docs.chef.io/deprecations_ohai_amazon_linux.html
+
+
 ## 3.0.0 (2018-04-29)
 
 - Require Chef 13 or later

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,11 +33,12 @@ when 'debian'
   default['grafana']['package']['apt_rebuild'] = true
   default['grafana']['package']['trusted'] = false
 when 'rhel', 'fedora', 'amazon'
-  if node['platform_family'] == 'amazon'
-    release_version = '7'
-  else
-    release_version = '$releasever'
-  end
+  release_version =
+    if node['platform_family'] == 'amazon'
+      '7'
+    else
+      '$releasever'
+    end
   default['grafana']['package']['repo'] = "https://packagecloud.io/grafana/stable/el/#{release_version}/$basearch"
   # default['grafana']['package']['repo'] = 'https://packagecloud.io/grafana/stable/el/$releasever/$basearch'
   default['grafana']['package']['key'] = 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,9 +32,15 @@ when 'debian'
   default['grafana']['package']['version'] = node['grafana']['version']
   default['grafana']['package']['apt_rebuild'] = true
   default['grafana']['package']['trusted'] = false
-when 'rhel', 'fedora'
-  default['grafana']['package']['repo'] = 'https://packagecloud.io/grafana/stable/el/$releasever/$basearch'
-  default['grafana']['package']['key'] = 'https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana'
+when 'rhel', 'fedora', 'amazon'
+  if node['platform_family'] == 'amazon'
+    release_version = '7'
+  else
+    release_version = '$releasever'
+  end
+  default['grafana']['package']['repo'] = "https://packagecloud.io/grafana/stable/el/#{release_version}/$basearch"
+  # default['grafana']['package']['repo'] = 'https://packagecloud.io/grafana/stable/el/$releasever/$basearch'
+  default['grafana']['package']['key'] = 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana'
   default['grafana']['package']['version'] = "#{node['grafana']['version']}-1"
   default['grafana']['package']['checkkey'] = true
 end
@@ -50,7 +56,7 @@ default['grafana']['pid_dir'] = '/var/run/grafana'
 case node['platform_family']
 when 'debian'
   default['grafana']['env_dir'] = '/etc/default'
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   default['grafana']['env_dir'] = '/etc/sysconfig'
 end
 default['grafana']['conf_dir'] = '/etc/grafana'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,7 +35,7 @@ when 'debian'
 when 'rhel', 'fedora', 'amazon'
   release_version =
     if node['platform_family'] == 'amazon'
-      '7'
+      '6'
     else
       '$releasever'
     end

--- a/recipes/_install_file.rb
+++ b/recipes/_install_file.rb
@@ -40,7 +40,7 @@ when 'debian'
     options '--force-confdef,confnew'
     not_if grafana_installed
   end
-when 'rhel'
+when 'rhel', 'amazon'
   package %w(initscripts fontconfig urw-fonts)
 
   grafana_installed = "yum list installed | grep grafana | grep #{node['grafana']['version']}"

--- a/recipes/_install_package.rb
+++ b/recipes/_install_package.rb
@@ -35,7 +35,7 @@ when 'debian'
     version node['grafana']['package']['version']
     options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
   end
-when 'rhel'
+when 'rhel', 'amazon'
   yum_repository 'grafana' do
     description 'Grafana Stable Repo'
     baseurl node['grafana']['package']['repo']


### PR DESCRIPTION
### Description

Add support for amazonlinux.

### Issues Resolved
Chef 13 and later evaluates node['platform_family'] as 'amazon' so this cookbook does not work with later versions of chef on amazon linux: https://docs.chef.io/deprecations_ohai_amazon_linux.html

### Check List
- [ x ] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md

anson.kee@Jobvites-MacBook-Pro-105 ~JOBVITE/grafana (master●●)$ kitchen verify                                                                                                      [ruby-2.5.1]
-----> Starting Kitchen (v1.23.2)
-----> Verifying <default-amazonlinux>...
       Loaded tests from {:path=>".Users.anson.kee.code.bitbucket.DevOps.grafana.test.integration.default"}

Profile: tests from {:path=>"/Users/anson.kee/code/bitbucket/DevOps/grafana/test/integration/default"} (tests from {:path=>".Users.anson.kee.code.bitbucket.DevOps.grafana.test.integration.default"})
Version: (not specified)
Target:  ssh://ec2-user@172.25.120.93:22

  File /usr/sbin/grafana-server
     ✔  should be a file
     ✔  should be owned by "root"
     ✔  should be grouped into "root"
  File /etc/sysconfig/grafana-server
     ✔  should be a file
     ✔  should be owned by "root"
     ✔  should be grouped into "root"
  File /etc/grafana/grafana.ini
     ✔  should be a file
     ✔  should be owned by "root"
     ✔  should be grouped into "grafana"
  Service grafana-server
     ✔  should be enabled
  1 #
     ✔  should be running
  File /etc/nginx/sites-enabled/Grafana
     ✔  should be file
     ✔  should be linked to "/etc/nginx/sites-available/Grafana"
     ✔  should be owned by "root"
     ✔  should be grouped into "root"
     ✔  content should match /server 127.0.0.1:3000;/
     ✔  content should match /proxy_pass http:\/\/grafana;/
  Command: `curl http://127.0.0.1:3000/`
     ✔  stdout should match /<a href="\/login">Found<\/a>/

Test Summary: 18 successful, 0 failures, 0 skipped
       Finished verifying <default-amazonlinux> (0m11.31s).
-----> Verifying <package-amazonlinux>...

Test Summary: 0 successful, 0 failures, 0 skipped
       Finished verifying <package-amazonlinux> (0m4.94s).
-----> Kitchen is finished. (0m21.49s)
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
