### PR TITLE
Marks LDAP template as sensitive

### DIFF
--- a/recipes/_ldap_config.rb
+++ b/recipes/_ldap_config.rb
@@ -7,5 +7,6 @@ template node['grafana']['ini']['auth.ldap']['config_file']['value'] do
   owner 'root'
   group 'root'
   mode '0644'
+  sensitive true
   # notifies :restart, 'service[grafana-server]', :delayed
 end


### PR DESCRIPTION
Fixes leaking of sensitive data such as bind_password

### Description

Fixes leaking of sensitive data such as bind_password

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
