### PR TITLE
Add login_cookie_name property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of grafana.
 - Create a new config resource to be able to configure the grafana instance
 - Create install resource to install Grafana, does not do any configuration
 - Update repo location to new grafana repos (#220)
+- Add login_cookie_name property to config_auth resource
 
 ## 3.0.1 (2018-11-27)
 

--- a/resources/config_auth.rb
+++ b/resources/config_auth.rb
@@ -20,6 +20,7 @@
 property  :instance_name,                                 String,         name_property: true
 property  :conf_directory,                                String,         default: '/etc/grafana'
 property  :config_file,                                   String,         default: lazy { ::File.join(conf_directory, 'grafana.ini') }
+property  :login_cookie_name,                             String,         default: 'grafana_session'
 property  :disable_login_form,                            [true, false],  default: false
 property  :disable_signout_menu,                          [true, false],  default: false
 property  :signout_redirect_url,                          String,         default: ''
@@ -107,6 +108,8 @@ action :install do
       cookbook new_resource.cookbook
 
       variables['grafana']['auth'] ||= {}
+      variables['grafana']['auth']['login_cookie_name'] ||= '' unless new_resource.login_cookie_name.nil?
+      variables['grafana']['auth']['login_cookie_name'] << new_resource.login_cookie_name.to_s unless new_resource.login_cookie_name.nil?
       variables['grafana']['auth']['disable_login_form'] ||= '' unless new_resource.disable_login_form.nil?
       variables['grafana']['auth']['disable_login_form'] << new_resource.disable_login_form.to_s unless new_resource.disable_login_form.nil?
       variables['grafana']['auth']['disable_signout_menu'] ||= '' unless new_resource.disable_signout_menu.nil?

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -355,6 +355,11 @@ viewers_can_edit = <%= @grafana['users']['viewers_can_edit'] %>
 
 <% if @grafana['auth'] %>
 [auth]
+# Login cookie name
+<% if @grafana['auth']['login_cookie_name'] %>
+login_cookie_name = <%= @grafana['auth']['login_cookie_name'] %>
+<% end %>
+
 # Set to true to disable (hide) the login form, useful if you use OAuth
 <% if @grafana['auth']['disable_login_form'] %>
 disable_login_form = <%= @grafana['auth']['disable_login_form'] %>


### PR DESCRIPTION
### Description

Adds `login_cookie_name` to `config_auth` resource.

### Issues Resolved

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
