### PR TITLE
Add root_url property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of grafana.
 - Create install resource to install Grafana, does not do any configuration
 - Update repo location to new grafana repos (#220)
 - Add login_cookie_name property to config_auth resource
+- Add root_url property to config_server resource
 
 ## 3.0.1 (2018-11-27)
 

--- a/resources/config_server.rb
+++ b/resources/config_server.rb
@@ -25,6 +25,7 @@ property  :protocol,          String,         default: 'http', equal_to: %w(http
 property  :http_addr,         String,         default: ''
 property  :http_port,         Integer,        default: 3000
 property  :domain,            String,         default: node['hostname']
+property  :root_url,          String,         default: '%(protocol)s://%(domain)s:%(http_port)s/'
 property  :enforce_domain,    [true, false],  default: false
 property  :router_logging,    [true, false],  default: false
 property  :static_root_path,  String,         default: 'public'
@@ -51,6 +52,8 @@ action :install do
       variables['grafana']['server']['http_port'] << new_resource.http_port.to_s unless new_resource.http_port.nil?
       variables['grafana']['server']['domain'] ||= '' unless new_resource.domain.nil?
       variables['grafana']['server']['domain'] << new_resource.domain.to_s unless new_resource.domain.nil?
+      variables['grafana']['server']['root_url'] ||= '' unless new_resource.root_url.nil?
+      variables['grafana']['server']['root_url'] << new_resource.root_url.to_s unless new_resource.root_url.nil?
       variables['grafana']['server']['enforce_domain'] ||= '' unless new_resource.enforce_domain.nil?
       variables['grafana']['server']['enforce_domain'] << new_resource.enforce_domain.to_s unless new_resource.enforce_domain.nil?
       variables['grafana']['server']['router_logging'] ||= '' unless new_resource.router_logging.nil?

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -76,7 +76,9 @@ enforce_domain = <%= @grafana['server']['enforce_domain'] %>
 <% end %>
 
 # The full public facing url
-root_url = %(protocol)s://%(domain)s:%(http_port)s/
+<% if @grafana['server']['root_url'] %>
+root_url = <%= @grafana['server']['root_url'] %>
+<% end %>
 
 # Log web requests
 <% if @grafana['server']['router_logging'] %>


### PR DESCRIPTION
### Description

Adds `root_url` to `config_server` resource.

### Issues Resolved

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
