### PR TITLE
Adding 'amazon' platform to install resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/sous-chefs/chef-grafana'
 issues_url       'https://github.com/sous-chefs/chef-grafana/issues'
 chef_version     '>= 13.0'
-version          '4.0.0'
+version          '4.0.1'
 
 supports 'debian'
 supports 'ubuntu'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -30,7 +30,7 @@ action :install do
   case node['platform_family']
   when 'debian'
     repository = "#{new_resource.repo}/deb"
-  when 'rhel'
+  when 'rhel', 'amazon'
     repository = "#{new_resource.repo}/rpm"
   end
 


### PR DESCRIPTION
### Description
Adding 'amazon' platform to install resource

### Issues Resolved
Fixes: #229

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/grafana/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
