### PR TITLE
Add HTTP PATCH for org user update

### DIFF
--- a/libraries/api_helper.rb
+++ b/libraries/api_helper.rb
@@ -63,6 +63,8 @@ module GrafanaCookbook
       session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
       http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
       request = case grafana_options[:method]
+                when 'Patch'
+                  Net::HTTP::Patch.new(grafana_options[:endpoint])
                 when 'Post'
                   Net::HTTP::Post.new(grafana_options[:endpoint])
                 when 'Put'


### PR DESCRIPTION
### Description

Updates do_request to support required HTTP method.

Org api requires PATCH as per [docs](https://grafana.com/docs/http_api/org/#updates-the-given-user). But do_request does not support it.
https://github.com/sous-chefs/grafana/blob/b97ef5428c0a545548e62e263f189023be8b729c/libraries/organization_api.rb#L76


### Steps to Reproduce

Given user org role change
```
grafana_user 'j.smith' do
  user(
    organizations: [
      { name: 'Org. 2', role: 'Admin' }
    ]
  )
  action :update
end
```
Result:
```
ERROR: Endpoint not found when sending GET /api/org/users/2
```