### PR TITLE
Adds an `include_repo` boolean property to install resource

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -25,6 +25,7 @@ property :key,              String, default:  'https://packages.grafana.com/gpg.
 property :rpm_key,          String, default:  'https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana'
 property :deb_distribution, String, default:  'stable'
 property :deb_components,   Array,  default:  ['main']
+property :include_repo      [TrueClass, FalseClass], default: true
 
 action :install do
   case node['platform_family']
@@ -46,6 +47,7 @@ action :install do
       key           new_resource.key
       cache_rebuild true
       trusted       false
+      only_if       { new_resource.include_repo }
     end
 
     # There is an issue on debian based systems which causes the error:
@@ -60,6 +62,7 @@ action :install do
       baseurl       repository
       gpgkey        "#{new_resource.key} #{new_resource.rpm_key}"
       gpgcheck      true
+      only_if       { new_resource.include_repo }
     end
 
     package 'grafana' do


### PR DESCRIPTION
Some users have external repository management infrastructure and prefer
that cookbooks don't manage repos at all. For instance: an air-gapped
environment with a Red Hat Satellite server providing yum content.

## Check List

- [ ] All tests pass. See TESTING.md for details
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
