### PR TITLE
 Grafana needs restart after plugins updated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,3 +33,8 @@ workflows:
           suite: ldap
           requires:
             *lint_and_unit
+      - kitchen/dokken-single:
+          name: plugins
+          suite: plugins
+          requires:
+            *lint_and_unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## Unreleased
+
+- after modifying plugins, grafana-server is restarted
+
 ## 4.4.0 (2019-05-21)
 
 - grafana_plugin now works

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,3 +27,7 @@ suites:
   - name: ldap
     run_list:
       - recipe[test::ldap]
+
+  - name: plugins
+    run_list:
+      - recipe[test::plugins]

--- a/test/fixtures/cookbooks/test/recipes/plugins.rb
+++ b/test/fixtures/cookbooks/test/recipes/plugins.rb
@@ -1,0 +1,11 @@
+grafana_install 'grafana'
+
+grafana_config 'Grafana'
+grafana_config_auth 'Grafana' do
+  # for api testing
+  anonymous_enabled true
+end
+
+grafana_plugin 'grafana-clock-panel' do
+  action :install
+end

--- a/test/integration/plugins/plugins_spec.rb
+++ b/test/integration/plugins/plugins_spec.rb
@@ -1,7 +1,13 @@
-describe command('grafana-server -v') do
-  its(:stdout) { should match /Version 3.0.3/ }
+describe command('grafana-cli plugins ls') do
+  its(:stdout) { should include 'grafana-clock-panel' }
 end
 
-describe command('grafana-cli plugins ls') do
-  its(:stdout) { should match /grafana-clock-panel/ }
+describe http('http://localhost:3000/api/frontend/settings') do
+  its('status') { should eq 200 }
+
+  let(:json) { JSON.parse(subject.body) }
+  it { expect(json).to be_a Hash }
+
+  it { expect(json).to have_key 'panels' }
+  it { expect(json['panels']).to have_key 'grafana-clock-panel' }
 end


### PR DESCRIPTION
Docs: https://grafana.com/docs/plugins/installation/
> after modifying plugins, grafana-server needs to be restarted.

There was an existing `plugins_spec.rb` that was unused. Added it to test suite.