### PR TITLE
API should handle recent service restarts

### DIFF
--- a/libraries/api_helper.rb
+++ b/libraries/api_helper.rb
@@ -16,7 +16,7 @@ module GrafanaCookbook
       request.add_field('Content-Type', 'application/json;charset=utf-8')
       request.body = { 'User' => user, 'email' => '', 'Password' => password }.to_json
 
-      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
+      response = with_limited_retry tries: 10, exceptions: [Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL] do
         http.request(request)
       end
 
@@ -83,7 +83,7 @@ module GrafanaCookbook
       request.add_field('Accept', 'application/json')
       request.body = payload if payload
 
-      response = with_limited_retry tries: 10, exceptions: Errno::ECONNREFUSED do
+      response = with_limited_retry tries: 10, exceptions: [Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL] do
         http.request(request)
       end
 


### PR DESCRIPTION
# Description
There exists a race condition where the api library tries to connect to the service before the service has completed `bind(2)`.

Fixes error:
> Errno::EADDRNOTAVAIL: Failed to open TCP connection to localhost:3000 (Cannot assign requested address - connect(2) for "localhost" port 3000)