### PR TITLE
Add allow_embedded to security to allow iframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 4.4.1 (2019-05-30)
+
+- New Grafana attribute allow_embedded can be set.
+
 ## 4.4.0 (2019-05-21)
 
 - grafana_plugin now works

--- a/documentation/grafana_config_security.md
+++ b/documentation/grafana_config_security.md
@@ -27,6 +27,7 @@ Introduced: v4.0.0
 | `config_file`                           | String      | `/etc/grafana/grafana.ini`  | The Grafana configuration file                          | Valid file path
 | `cookbook`                              | String      | `grafana`                   | Which cookbook to look in for the template              |
 | `source`                                | String      | `grafana.ini.erb`           | Name of the template                                    |
+| `allow_embedding`                       | true, false | `false`                     | Turn on iframe access
 
 ## Examples
 

--- a/documentation/grafana_config_security.md
+++ b/documentation/grafana_config_security.md
@@ -27,7 +27,7 @@ Introduced: v4.0.0
 | `config_file`                           | String      | `/etc/grafana/grafana.ini`  | The Grafana configuration file                          | Valid file path
 | `cookbook`                              | String      | `grafana`                   | Which cookbook to look in for the template              |
 | `source`                                | String      | `grafana.ini.erb`           | Name of the template                                    |
-| `allow_embedding`                       | String      | `false`                     | Turn on iframe access
+| `allow_embedding`                       | true, false | `false`                     | Turn on iframe access
 
 ## Examples
 

--- a/documentation/grafana_config_security.md
+++ b/documentation/grafana_config_security.md
@@ -27,6 +27,7 @@ Introduced: v4.0.0
 | `config_file`                           | String      | `/etc/grafana/grafana.ini`  | The Grafana configuration file                          | Valid file path
 | `cookbook`                              | String      | `grafana`                   | Which cookbook to look in for the template              |
 | `source`                                | String      | `grafana.ini.erb`           | Name of the template                                    |
+| `allow_embedding`                       | String      | `false`                     | Turn on iframe access
 
 ## Examples
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,25 +5,54 @@ driver:
 provisioner:
   name: chef_zero
   product_name: chef
-  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  product_version: 14
+  http_proxy: <%= ENV['http_proxy'] %>
+  https_proxy: <%= ENV['https_proxy'] %>
+  no_proxy: <%= ENV['no_proxy'] %>
   install_strategy: once
 
 client_rb:
   treat_deprecation_warnings_as_errors: true
+
 verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-16.04
-  - name: ubuntu-18.04
-  - name: centos-6
   - name: centos-7
 
 suites:
   - name: default
+    driver:
+      network:
+      - ["private_network", {ip: "192.168.56.107"}]
     run_list:
       - recipe[test::install]
-
   - name: ldap
     run_list:
       - recipe[test::ldap]
+
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:
+
+  # deprecations_as_errors: true
+
+  # environments_path: "../../environments"
+  # data_bags_path: "../../data_bags"
+  # nodes_path: "../../nodes"
+  # roles_path: "../../roles"
+
+  # client_rb: kitchen  
+
+# verifier:
+#   name: inspec
+
+# suites:
+#   - name: default
+#     run_list:
+#       - recipe[ssnc-metrictank::default]
+#     verifier:
+#       inspec_tests:
+#         - test/integration/default
+#             attributes:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,7 +5,7 @@ driver:
 provisioner:
   name: chef_zero
   product_name: chef
-  product_version: 14
+  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   http_proxy: <%= ENV['http_proxy'] %>
   https_proxy: <%= ENV['https_proxy'] %>
   no_proxy: <%= ENV['no_proxy'] %>
@@ -13,46 +13,20 @@ provisioner:
 
 client_rb:
   treat_deprecation_warnings_as_errors: true
-
 verifier:
   name: inspec
 
 platforms:
+  - name: ubuntu-16.04	
+  - name: ubuntu-18.04	
+  - name: centos-6
   - name: centos-7
 
 suites:
   - name: default
-    driver:
-      network:
-      - ["private_network", {ip: "192.168.56.107"}]
     run_list:
       - recipe[test::install]
+
   - name: ldap
     run_list:
       - recipe[test::ldap]
-
-    verifier:
-      inspec_tests:
-        - test/integration/default
-    attributes:
-
-  # deprecations_as_errors: true
-
-  # environments_path: "../../environments"
-  # data_bags_path: "../../data_bags"
-  # nodes_path: "../../nodes"
-  # roles_path: "../../roles"
-
-  # client_rb: kitchen  
-
-# verifier:
-#   name: inspec
-
-# suites:
-#   - name: default
-#     run_list:
-#       - recipe[ssnc-metrictank::default]
-#     verifier:
-#       inspec_tests:
-#         - test/integration/default
-#             attributes:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,7 +5,8 @@ driver:
 provisioner:
   name: chef_zero
   product_name: chef
-  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  # product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  product_version: 14
   http_proxy: <%= ENV['http_proxy'] %>
   https_proxy: <%= ENV['https_proxy'] %>
   no_proxy: <%= ENV['no_proxy'] %>

--- a/resources/config_security.rb
+++ b/resources/config_security.rb
@@ -32,7 +32,7 @@ property  :data_source_proxy_whitelist,           String,         default: ''
 property  :disable_brute_force_login_protection,  [true, false],  default: false
 property  :cookbook,                              String,         default: 'grafana'
 property  :source,                                String,         default: 'grafana.ini.erb'
-property  :allow_embedding,                       String,         default: false
+property  :allow_embedding,                       [true, false],         default: false
 
 action :install do
   with_run_context :root do

--- a/resources/config_security.rb
+++ b/resources/config_security.rb
@@ -32,6 +32,7 @@ property  :data_source_proxy_whitelist,           String,         default: ''
 property  :disable_brute_force_login_protection,  [true, false],  default: false
 property  :cookbook,                              String,         default: 'grafana'
 property  :source,                                String,         default: 'grafana.ini.erb'
+property  :allow_embedding,                       [true, false],         default: false
 
 action :install do
   with_run_context :root do
@@ -59,7 +60,8 @@ action :install do
       variables['grafana']['security']['data_source_proxy_whitelist'] << new_resource.data_source_proxy_whitelist.to_s unless new_resource.data_source_proxy_whitelist.nil?
       variables['grafana']['security']['disable_brute_force_login_protection'] ||= '' unless new_resource.disable_brute_force_login_protection.nil?
       variables['grafana']['security']['disable_brute_force_login_protection'] << new_resource.disable_brute_force_login_protection.to_s unless new_resource.disable_brute_force_login_protection.nil?
-
+      variables['grafana']['security']['allow_embedding'] ||= '' unless new_resource.allow_embedding.nil?
+      variables['grafana']['security']['allow_embedding'] << new_resource.allow_embedding.to_s unless new_resource.allow_embedding.nil?
       action :nothing
       delayed_action :create
     end

--- a/resources/config_security.rb
+++ b/resources/config_security.rb
@@ -32,6 +32,7 @@ property  :data_source_proxy_whitelist,           String,         default: ''
 property  :disable_brute_force_login_protection,  [true, false],  default: false
 property  :cookbook,                              String,         default: 'grafana'
 property  :source,                                String,         default: 'grafana.ini.erb'
+property  :allow_embedding,                       String,         default: false
 
 action :install do
   with_run_context :root do
@@ -59,7 +60,8 @@ action :install do
       variables['grafana']['security']['data_source_proxy_whitelist'] << new_resource.data_source_proxy_whitelist.to_s unless new_resource.data_source_proxy_whitelist.nil?
       variables['grafana']['security']['disable_brute_force_login_protection'] ||= '' unless new_resource.disable_brute_force_login_protection.nil?
       variables['grafana']['security']['disable_brute_force_login_protection'] << new_resource.disable_brute_force_login_protection.to_s unless new_resource.disable_brute_force_login_protection.nil?
-
+      variables['grafana']['security']['allow_embedding'] ||= '' unless new_resource.allow_embedding.nil?
+      variables['grafana']['security']['allow_embedding'] << new_resource.allow_embedding.to_s unless new_resource.allow_embedding.nil?
       action :nothing
       delayed_action :create
     end

--- a/resources/config_security.rb
+++ b/resources/config_security.rb
@@ -32,7 +32,7 @@ property  :data_source_proxy_whitelist,           String,         default: ''
 property  :disable_brute_force_login_protection,  [true, false],  default: false
 property  :cookbook,                              String,         default: 'grafana'
 property  :source,                                String,         default: 'grafana.ini.erb'
-property  :allow_embedding,                       [true, false],         default: false
+property  :allow_embedding,                       [true, false],  default: false
 
 action :install do
   with_run_context :root do

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -267,6 +267,12 @@ data_source_proxy_whitelist = <%= @grafana['security']['data_source_proxy_whitel
 <% if @grafana['security']['disable_brute_force_login_protection'] %>
 disable_brute_force_login_protection = <%= @grafana['security']['disable_brute_force_login_protection'] %>
 <% end %>
+
+# allow grafana to exist in iframes
+<% if @grafana['security']['allow_embedding'] %>
+allow_embedding = <%= @grafana['security']['allow_embedding'] %>
+<% end %>
+
 <% end %>
 #################################### Snapshots ###########################
 <% if @grafana['snapshots'] %>


### PR DESCRIPTION
# Description
Add the ability to set the new allow_embedded flag to the security section of grafana.ini
## Issues Resolved
Corrects https://github.com/sous-chefs/grafana/issues/268
## Check List
- [ ] All tests pass. See TESTING.md for details
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
