### PR TITLE
Add support for config remote cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of grafana.
 
+## Unreleased
+
+- Fixed session `provider`
+- Added remote-cache config support
+
 ## 5.0.0 (2019-06-20)
 
 - Allow custom database names

--- a/documentation/grafana_config_remote_cache.md
+++ b/documentation/grafana_config_remote_cache.md
@@ -1,0 +1,37 @@
+[back to resource list](https://github.com/sous-chefs/grafana#resources)
+
+---
+
+# grafana_config_remote_cache
+
+Configures the remote cache section of the configuration <http://docs.grafana.org/installation/configuration/#remote-cache>.
+
+Introduced: v6.2.0
+
+## Actions
+
+`:create`
+
+## Properties
+
+| Name                | Type        |  Default                                  | Description                                             | Allowed Values
+| ------------------- | ----------- | ----------------------------------------- | ------------------------------------------------------- | --------------- |
+| `remote_cache_type` | String      | `database`                                | Provider to use                                         |redis memcached database
+| `remote_cache_config`   | String      |                                       | See <https://grafana.com/docs/installation/configuration/#connstr> |
+| `conf_directory`    | String      | `/etc/grafana`                            | The directory where the Grafana configuration resides   | Valid directory
+| `config_file`       | String      | `/etc/grafana/grafana.ini`                | The Grafana configuration file                          | Valid file path
+| `cookbook`          | String      | `grafana`                                 | Which cookbook to look in for the template              |
+| `source`            | String      | `grafana.ini.erb`                         | Name of the template                                    |
+
+## Examples
+
+```ruby
+grafana_config_remote_cache 'grafana'
+```
+
+```ruby
+grafana_config_remote_cache 'grafana' do
+  type 'memcached'
+  connstr '127.0.0.1:11211'
+end
+```

--- a/documentation/grafana_config_session.md
+++ b/documentation/grafana_config_session.md
@@ -4,9 +4,10 @@
 
 # grafana_config_session
 
-Configures the core session section of the configuration <http://docs.grafana.org/installation/configuration/#session>
+Configures the core session section of the configuration <http://docs.grafana.org/installation/configuration/#session>. Note, if you're using Grafana v6.2 or newer, cookie/session settings are in Remote Cache and Security. See <https://grafana.com/docs/installation/configuration/#remote-cache> and <https://grafana.com/docs/installation/configuration/#security>.
 
 Introduced: v4.0.0
+Removed: v6.2.0
 
 ## Actions
 
@@ -18,6 +19,7 @@ Introduced: v4.0.0
 | ------------------- | ----------- | ----------------------------------------- | ------------------------------------------------------- | --------------- |
 | `session_provider`  | String      | `file`                                    | Provider to use                                         |memory file redis mysql postgres memcache
 | `provider_config`   | String      | `sessions`                                | See <http://docs.grafana.org/installation/configuration/#session> |
+| `cookie_name`       | String      | `grafana_sess`                            | Session cookie name                           |
 | `cookie_secure`     | true, false | `false`                                   | Set to true if you host Grafana behind HTTPS only. Defaults to false. | true, false
 | `session_life_time` | Integer     | `86400`                                   | How long sessions lasts in seconds. Defaults to 86400 (24 hours).|
 | `gc_interval_time`  | Integer     | `86400`                                   | How often to garbase collect                            |

--- a/resources/config_remote_cache.rb
+++ b/resources/config_remote_cache.rb
@@ -1,0 +1,46 @@
+#
+# Cookbook Name:: grafana
+# Resource:: config_remote_cache
+#
+# Copyright 2018, Sous Chefs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Configures the installed grafana instance
+
+property  :instance_name,       String,         name_property: true
+property  :conf_directory,      String,         default: '/etc/grafana'
+property  :config_file,         String,         default: lazy { ::File.join(conf_directory, 'grafana.ini') }
+property  :remote_cache_type,   String,         default: 'database', equal_to: %w(redis memcached database)
+property  :remote_cache_config, String,         default: ''
+property  :cookbook,            String,         default: 'grafana'
+property  :source,              String,         default: 'grafana.ini.erb'
+
+action :install do
+  with_run_context :root do
+    edit_resource(:template, new_resource.config_file) do |new_resource|
+      node.run_state['grafana'] ||= { 'conf_template_source' => {}, 'conf_cookbook' => {} }
+      source new_resource.source
+      cookbook new_resource.cookbook
+
+      variables['grafana']['remote_cache'] ||= {}
+      variables['grafana']['remote_cache']['type'] ||= '' unless new_resource.remote_cache_type.nil?
+      variables['grafana']['remote_cache']['type'] << new_resource.remote_cache_type.to_s unless new_resource.remote_cache_type.nil?
+      variables['grafana']['remote_cache']['connstr'] ||= '' unless new_resource.remote_cache_config.nil?
+      variables['grafana']['remote_cache']['connstr'] << new_resource.remote_cache_config.to_s unless new_resource.remote_cache_config.nil?
+
+      action :nothing
+      delayed_action :create
+    end
+  end
+end

--- a/resources/config_session.rb
+++ b/resources/config_session.rb
@@ -41,7 +41,7 @@ action :install do
 
       variables['grafana']['session'] ||= {}
       variables['grafana']['session']['provider'] ||= '' unless new_resource.session_provider.nil?
-      variables['grafana']['session']['provider'] << new_resource.provider.to_s unless new_resource.session_provider.nil?
+      variables['grafana']['session']['provider'] << new_resource.session_provider.to_s unless new_resource.session_provider.nil?
       variables['grafana']['session']['provider_config'] ||= '' unless new_resource.provider_config.nil?
       variables['grafana']['session']['provider_config'] << new_resource.provider_config.to_s unless new_resource.provider_config.nil?
       variables['grafana']['session']['cookie_name'] ||= '' unless new_resource.cookie_name.nil?

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -207,6 +207,23 @@ gc_interval_time = <%= @grafana['session']['gc_interval_time'] %>
 conn_max_lifetime = <%= @grafana['session']['conn_max_lifetime'] %>
 <% end %>
 <% end %>
+#################################### Remote Cache #############################
+<% if @grafana['remote_cache'] %>
+[remote_cache]
+# Either "redis", "memcached", "database" default is "database"
+<% if @grafana['remote_cache']['type'] %>
+type = <%= @grafana['remote_cache']['type'] %>
+<% end %>
+
+# The remote cache connection string.
+# Leave empty when using database since it will use the primary database.
+# Redis example config: addr=127.0.0.1:6379,pool_size=100,db=grafana
+# Memcache example: 127.0.0.1:11211
+<% if @grafana['remote_cache']['connstr'] %>
+connstr = <%= @grafana['remote_cache']['connstr'] %>
+<% end %>
+<% end %>
+
 #################################### Data proxy ###########################
 <% if @grafana['dataproxy'] %>
 [dataproxy]

--- a/test/fixtures/cookbooks/test/recipes/install.rb
+++ b/test/fixtures/cookbooks/test/recipes/install.rb
@@ -16,7 +16,10 @@ grafana_config_paths 'Grafana'
 grafana_config_quota 'Grafana'
 grafana_config_security 'Grafana'
 grafana_config_server 'Grafana'
-grafana_config_session 'Grafana'
+grafana_config_session 'Grafana' do
+  session_provider 'memory'
+end
+grafana_config_remote_cache 'Grafana'
 grafana_config_smtp 'Grafana'
 grafana_config_snapshots 'Grafana'
 grafana_config_users 'Grafana'


### PR DESCRIPTION
Also fixes old config session 'provider'

Signed-off-by: Nathan Haneysmith <nathan@chef.io>

# Description

[Describe what this change achieves]
Related to #248 
As of Grafana 6.2, instead of using "session" config block, these settings have been moved to security and remote cache. This adds support for remote cache.

Also fixes a problem with session provider where the value would always be nil.

## Issues Resolved

[List any existing issues this PR resolves]

## Check List

- [x] All tests pass. See TESTING.md for details
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
