### PR TITLE
fixing the wrong metrics configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of grafana.
 
 ## 5.1.1 (2019-08-16)
 
-- Fixed session `address` appearing as `basic_auth_password` for internal metrics
+- Fixed `address` appearing as `basic_auth_password` for internal metrics
 
 ## 5.1.0 (2019-07-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 5.1.1 (2019-08-16)
+
+- Fixed session `address` appearing as `basic_auth_password` for internal metrics
+
 ## 5.1.0 (2019-07-26)
 
 - After modifying config files, grafana-server is restarted

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/sous-chefs/chef-grafana'
 issues_url       'https://github.com/sous-chefs/chef-grafana/issues'
 chef_version     '>= 13.0'
-version          '5.1.0'
+version          '5.1.1'
 
 supports 'debian'
 supports 'ubuntu'

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -967,7 +967,7 @@ basic_auth_password = <%= @grafana['metrics']['basic_auth_password'] %>
 [metrics.graphite]
 # Enable by setting the address setting (ex localhost:2003)
 <% if @grafana['metrics_graphite']['address'] %>
-basic_auth_password = <%= @grafana['metrics_graphite']['address'] %>
+address = <%= @grafana['metrics_graphite']['address'] %>
 <% end %>
 <% if @grafana['metrics_graphite']['prefix'] %>
 prefix = <%= @grafana['metrics_graphite']['prefix'] %>


### PR DESCRIPTION
# Description

Fixes the "Metrics" configuration section where basic_auth_password appears instead of address

## Issues Resolved

Internal Metrics cannot be configured

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
