### PR TITLE
Makes group_search_base_dns array as orig. intended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of grafana.
 
-## UNRELEASED
+## Unreleased
 
 - Fixed type specification of group_search_dns to be Array instead
   of incorrect String previously.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of grafana.
 
+## UNRELEASED
+
+- Fixed type specification of group_search_dns to be Array instead
+  of incorrect String previously.
+
 ## 5.1.1 (2019-08-16)
 
 - Fixed `address` appearing as `basic_auth_password` for internal metrics

--- a/documentation/grafana_config_ldap_servers.md
+++ b/documentation/grafana_config_ldap_servers.md
@@ -2,7 +2,7 @@
 
 ---
 
-# grafana_config_ldap_group_mappings
+# grafana_config_ldap_servers
 
 Configures ldap servers <http://docs.grafana.org/auth/ldap/#grafana-ldap-configuration>
 
@@ -29,7 +29,7 @@ Introduced: v4.0.0
 | `search_filter`                       | String        | `(cn=%s)`                | User search filter |
 | `search_base_dns`                     | Array         |                          | An array of base dns to search through |
 | `group_search_filter`                 | String        |                          | POSIX, Group search filter, to retrieve the groups of which the user is a member  |
-| `group_search_base_dns`               | String        |                          | POSIX, An array of the base DNs to search through for groups. Typically uses ou=groups |
+| `group_search_base_dns`               | Array         |                          | POSIX, An array of the base DNs to search through for groups. Typically uses ou=groups |
 | `group_search_filter_user_attribute`  | String        |                          | POSIX, the %s in the search filter will be replaced with the attribute defined below |
 | `conf_directory`                      | String        | `/etc/grafana`           | The directory where the Grafana configuration resides                     | Valid directory
 | `config_file`                         | String        | `/etc/grafana/ldap.toml` | The Grafana configuration file                                            | Valid file path

--- a/resources/config_ldap_servers.rb
+++ b/resources/config_ldap_servers.rb
@@ -35,7 +35,7 @@ property  :bind_password,                       String,                   defaul
 property  :search_filter,                       String,                   default: '(cn=%s)'
 property  :search_base_dns,                     Array,                    default: []
 property  :group_search_filter,                 String
-property  :group_search_base_dns,               Array,                    default: []
+property  :group_search_base_dns,               Array, default: []
 property  :group_search_filter_user_attribute,  String
 property  :cookbook,                            String,                   default: 'grafana'
 property  :source,                              String,                   default: 'ldap.toml.erb'

--- a/resources/config_ldap_servers.rb
+++ b/resources/config_ldap_servers.rb
@@ -35,7 +35,7 @@ property  :bind_password,                       String,                   defaul
 property  :search_filter,                       String,                   default: '(cn=%s)'
 property  :search_base_dns,                     Array,                    default: []
 property  :group_search_filter,                 String
-property  :group_search_base_dns,               String
+property  :group_search_base_dns,               Array,                    default: []
 property  :group_search_filter_user_attribute,  String
 property  :cookbook,                            String,                   default: 'grafana'
 property  :source,                              String,                   default: 'ldap.toml.erb'


### PR DESCRIPTION
Fixes #279

Signed-off-by: Jeff Blaine <jblaine@mitre.org>

# Description

The type of the `group_search_base_dns` attribute to the `grafana_config_ldap_servers` resource was incorrectly defined as `String`. When specified as a string by a user of this cookbook, the TOML file rendered is invalid TOML. This PR changes the type to `Array` to match that of `user_search_base_dns` as originally intended (or that is my understanding).

## Issues Resolved

#279 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
