### PR TITLE
Config Resources restart fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 5.1.2 (2019-08-30)
+
+- Changed services to restart using subsriptions instead of inline on resource
+
 ## 5.1.1 (2019-08-16)
 
 - Fixed `address` appearing as `basic_auth_password` for internal metrics

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -82,8 +82,6 @@ action :install do
 
       action :nothing
       delayed_action :create
-      service 'grafana-server'
-      notifies :restart, 'service[grafana-server]'
     end
   end
 end

--- a/resources/config_ldap.rb
+++ b/resources/config_ldap.rb
@@ -33,7 +33,7 @@ property  :source,                        String, default: 'ldap.toml.erb'
 
 action :install do
   service 'grafana-server' do
-    action :enable
+    action :nothing
     subscribes :restart, "template[#{new_resource.config_file}]", :immediately
   end
 
@@ -59,8 +59,6 @@ action :install do
       variables['grafana']['ldap']['servers_attributes_email'] << new_resource.servers_attributes_email.to_s unless new_resource.servers_attributes_email.nil?
       action :nothing
       delayed_action :create
-      service 'grafana-server'
-      notifies :restart, 'service[grafana-server]'
     end
   end
 end

--- a/resources/config_remote_cache.rb
+++ b/resources/config_remote_cache.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: grafana
+# Cookbook:: grafana
 # Resource:: config_remote_cache
 #
-# Copyright 2018, Sous Chefs
+# Copyright:: 2018, Sous Chefs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description

Changed services to restart using subsriptions instead of inline on config resources

## Issues Resolved

#282

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
