### PR TITLE
fix: documentation/grafana_config_metrics.md

### DIFF
--- a/documentation/grafana_config_metrics.md
+++ b/documentation/grafana_config_metrics.md
@@ -17,10 +17,10 @@ Introduced: v4.0.0
 | Name                      | Type          |  Default                          | Description                                                               | Allowed Values
 | ------------------------- | ------------- | --------------------------------- | ------------------------------------------------------------------------- | --------------- |
 | `enabled`                 | true, false   | `true`                            | Enable metrics reporting                                                  | true, false
-| `interval_seconds`        | Integer       | `10`                              | If set configures the username to use for basic authentication on the metrics endpoint.|
-| `basic_auth_username`     | String        |                                   | If set configures the password to use for basic authentication on the metrics endpoint.|
-| `basic_auth_password`     | String        |                                   | Flush/Write interval when sending metrics to external TSDB. Defaults to 10s.|
-| `graphite_address`        | String        |                                   | Format Hostname or ip:port                                              |
+| `basic_auth_username`     | String        |                                   | If set configures the username to use for basic authentication on the metrics endpoint.|
+| `basic_auth_password`     | String        |                                   | If set configures the password to use for basic authentication on the metrics endpoint.|
+| `interval_seconds`        | Integer       | `10`                              | Flush/Write interval when sending metrics to external TSDB. Defaults to 10s.|
+| `graphite_address`        | String        |                                   | Format Hostname or ip:port                                                |
 | `graphite_prefix`         | String        | `prod.grafana.%(instance_name)s.` | Graphite metric prefix                                                    |
 | `conf_directory`          | String        | `/etc/grafana`                    | The directory where the Grafana configuration resides                     | Valid directory
 | `config_file`             | String        | `/etc/grafana/grafana.ini`        | The Grafana configuration file                                            | Valid file path


### PR DESCRIPTION
Messed up descriptions, plus properties order according to official documentation https://grafana.com/docs/installation/configuration/#metrics

Obvious fix.