### PR TITLE
fix: resources/config_server bad property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## UNRELEASED
+
+- Removed misconfigured duplicate router_logging String property in config_server resource.
+
 ## 6.0.0
 
 - Fixed type specification of group_search_dns to be Array instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of grafana.
 
 ## UNRELEASED
 
-- Removed misconfigured duplicate router_logging String property in config_server resource.
+- Removed misconfigured duplicate router_logging String property from config_server resource
 
 ## 6.0.0
 

--- a/resources/config_server.rb
+++ b/resources/config_server.rb
@@ -32,7 +32,6 @@ property  :static_root_path,  String,         default: 'public'
 property  :enable_gzip,       [true, false],  default: false
 property  :cert_file,         String,         default: ''
 property  :cert_key,          String,         default: ''
-property  :router_logging,    String,         default: '/tmp/grafana.sock'
 property  :cookbook,          String,         default: 'grafana'
 property  :source,            String,         default: 'grafana.ini.erb'
 


### PR DESCRIPTION
There are two properties with the same name (router_logging). Looks like the second one with type String is missconfigured and it shouldt have been here.
The only mention in repo about '/tmp/grafana.sock' that i can find is here:
https://github.com/sous-chefs/grafana/blob/master/templates/grafana.ini.erb#L107

Obvious fix.