### PR TITLE
fix: version selection for Debian-based install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of grafana.
 ## UNRELEASED
 
 - Removed misconfigured duplicate router_logging String property from config_server resource
+- Now correct Grafana version can be specified for installing/upgrading
+  on Debian based systems.
 
 ## 6.0.0
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -53,6 +53,7 @@ action :install do
     # this will allow grafana to be installed on 16.04 without compromising security of other systems
     package 'grafana' do
       options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --allow-unauthenticated'
+      version new_resource.version if new_resource.version
     end
   when 'rhel', 'amazon'
     yum_repository 'grafana' do


### PR DESCRIPTION
Obvious fix.

Fased with this issue when try to update my working installation on Ubuntu 16.04 with Grafana 6.3.6 to 6.4.0.
First of all i realised that after bumbing version in resource grafana_install nothing happends after chef-client run (and '* apt_package[grafana] action install (up to date)').
Than i removed apt package grafana manualy and tryed to install Grafana 6.3.6 with grafana_install resource again. And Grafana 6.4.0 was installed!
Looks like without this option 'version' in chef resource 'package' in resourse grafana_install when installing on Debian-based it will always install latest on first installation and wont updating Grafana version in future.