### PR TITLE
Add serve from sub path to grafana config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 7.1.0
+
+- Add option for `serve_from_sub_path` in grafana_config_server
+
 ## 7.0.0
 
 - Resolves issue with service restarts using external service resources

--- a/documentation/grafana_config_server.md
+++ b/documentation/grafana_config_server.md
@@ -21,6 +21,7 @@ Introduced: v4.0.0
 | `http_port`         | Integer     | `3000`                                    | The port to bind to, Privilaged ports will need you to add additional permissions|
 | `domain`            | String      | `node['hostname']`                        | This setting is only used in as a part of the root_url setting |
 | `root_url`          | String      | `%(protocol)s://%(domain)s:%(http_port)s/`| This is the full URL used to access Grafana from a web browser|
+| `serve_from_sub_path`| true, false | `false`                                  | Serve Grafana from subpath specified in root_url setting. Only available on Grafana 6.3 and above. Default is false|
 | `enforce_domain`    | true, false | `false`                                   | Redirect to correct domain if host header does not match domain. Prevents DNS rebinding attacks. Default is false.|
 | `router_logging`    | true, false | `false`                                   | Set to true for Grafana to log all HTTP requests (not just errors). | true, false
 | `static_root_path`  | String      | `public`                                  | The path to the directory where the front end files (HTML, JS, and CSS files)|

--- a/resources/config_server.rb
+++ b/resources/config_server.rb
@@ -18,22 +18,23 @@
 #
 # Configures the installed grafana instance
 
-property  :instance_name,     String,         name_property: true
-property  :conf_directory,    String,         default: '/etc/grafana'
-property  :config_file,       String,         default: lazy { ::File.join(conf_directory, 'grafana.ini') }
-property  :protocol,          String,         default: 'http', equal_to: %w(http https socket)
-property  :http_addr,         String,         default: ''
-property  :http_port,         Integer,        default: 3000
-property  :domain,            String,         default: node['hostname']
-property  :root_url,          String,         default: '%(protocol)s://%(domain)s:%(http_port)s/'
-property  :enforce_domain,    [true, false],  default: false
-property  :router_logging,    [true, false],  default: false
-property  :static_root_path,  String,         default: 'public'
-property  :enable_gzip,       [true, false],  default: false
-property  :cert_file,         String,         default: ''
-property  :cert_key,          String,         default: ''
-property  :cookbook,          String,         default: 'grafana'
-property  :source,            String,         default: 'grafana.ini.erb'
+property  :instance_name,        String,         name_property: true
+property  :conf_directory,       String,         default: '/etc/grafana'
+property  :config_file,          String,         default: lazy { ::File.join(conf_directory, 'grafana.ini') }
+property  :protocol,             String,         default: 'http', equal_to: %w(http https socket)
+property  :http_addr,            String,         default: ''
+property  :http_port,            Integer,        default: 3000
+property  :domain,               String,         default: node['hostname']
+property  :root_url,             String,         default: '%(protocol)s://%(domain)s:%(http_port)s/'
+property  :serve_from_sub_path,  [true, false],  default: false
+property  :enforce_domain,       [true, false],  default: false
+property  :router_logging,       [true, false],  default: false
+property  :static_root_path,     String,         default: 'public'
+property  :enable_gzip,          [true, false],  default: false
+property  :cert_file,            String,         default: ''
+property  :cert_key,             String,         default: ''
+property  :cookbook,             String,         default: 'grafana'
+property  :source,               String,         default: 'grafana.ini.erb'
 
 action :install do
   with_run_context :root do
@@ -53,6 +54,8 @@ action :install do
       variables['grafana']['server']['domain'] << new_resource.domain.to_s unless new_resource.domain.nil?
       variables['grafana']['server']['root_url'] ||= '' unless new_resource.root_url.nil?
       variables['grafana']['server']['root_url'] << new_resource.root_url.to_s unless new_resource.root_url.nil?
+      variables['grafana']['server']['serve_from_sub_path'] ||= '' unless new_resource.serve_from_sub_path.nil?
+      variables['grafana']['server']['serve_from_sub_path'] << new_resource.serve_from_sub_path.to_s unless new_resource.serve_from_sub_path.nil?
       variables['grafana']['server']['enforce_domain'] ||= '' unless new_resource.enforce_domain.nil?
       variables['grafana']['server']['enforce_domain'] << new_resource.enforce_domain.to_s unless new_resource.enforce_domain.nil?
       variables['grafana']['server']['router_logging'] ||= '' unless new_resource.router_logging.nil?

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 platforms = %w(debian ubuntu centos)
 platforms.each do |platform|
   describe "grafana_ on #{platform}" do
-    step_into :grafana_config, :grafana_install, :grafana_config_enterprise
+    step_into :grafana_config, :grafana_install, :grafana_config_enterprise, :grafana_config_server
     platform platform
 
     context 'create config with enterprise license key' do
@@ -20,6 +20,36 @@ platforms.each do |platform|
 
       it('should render config file') do
         is_expected.to render_file('/etc/grafana/grafana.ini').with_content(/license.txt/)
+      end
+    end
+
+    context 'create config without serve from sub path as default' do
+      recipe do
+        grafana_install 'package'
+
+        grafana_config 'config' do
+        end
+      end
+
+      it('should not contain serve_from_sub_path by default') do
+        is_expected.not_to render_file('/etc/grafana/grafana.ini').with_content(/serve_from_sub_path/)
+      end
+    end
+
+    context 'create config with server from sub path' do
+      recipe do
+        grafana_install 'package'
+
+        grafana_config 'config' do
+        end
+
+        grafana_config_server 'config' do
+          serve_from_sub_path true
+        end
+      end
+
+      it('should contain serve_from_sub_path') do
+        is_expected.to render_file('/etc/grafana/grafana.ini').with_content(/serve_from_sub_path/)
       end
     end
   end

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -80,6 +80,11 @@ enforce_domain = <%= @grafana['server']['enforce_domain'] %>
 root_url = <%= @grafana['server']['root_url'] %>
 <% end %>
 
+# Serve from subpath. Available only in grafana from version 6.3 and above.
+<% if @grafana['server']['serve_from_sub_path'] %>
+serve_from_sub_path = <%= @grafana['server']['serve_from_sub_path'] %>
+<% end %>
+
 # Log web requests
 <% if @grafana['server']['router_logging'] %>
 router_logging = <%= @grafana['server']['router_logging'] %>


### PR DESCRIPTION
This will add an option to enable `serve from sub path` which is an
option used in Grafana version 6.3 and above.

# Description

This PR will add an configuration option to enable the `serve_from_sub_path` option which is available from Grafana version 6.3 and above. https://grafana.com/docs/installation/configuration/#serve-from-sub-path

## Issues Resolved

Have not opened any issues on this.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
