### PR TITLE
Fix sensitive property of config_writer resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 8.1.1 (Unreleased)
+
+- Fix sensitive property of config_writer resource
+
 ## 8.1.0 (2019-11-26)
 
 - Generate Folder and folder permissions using Custom Resources

--- a/resources/config_writer.rb
+++ b/resources/config_writer.rb
@@ -21,7 +21,7 @@ action :install do
       grafana: node.run_state['sous-chefs'][new_resource.instance_name]['config']
     )
     not_if { node.run_state['sous-chefs'][new_resource.instance_name]['config'].nil? }
-    sensitive new_resource.sensitive
+    sensitive new_resource.is_sensitive
   end
 
   template ::File.join(new_resource.config_file_ldap) do
@@ -31,6 +31,6 @@ action :install do
       ldap: node.run_state['sous-chefs'][new_resource.instance_name]['ldap']
     )
     not_if { node.run_state['sous-chefs'][new_resource.instance_name]['ldap'].nil? }
-    sensitive new_resource.sensitive
+    sensitive new_resource.is_sensitive
   end
 end


### PR DESCRIPTION
# Description

The `is_sensitive` property on the config_writer resource is currently not working. This PR fixes that.

