### PR TITLE
Add role_attribute_path configuration for generic OAuth

### DIFF
--- a/documentation/grafana_config_auth.md
+++ b/documentation/grafana_config_auth.md
@@ -67,23 +67,24 @@ Introduced: v4.0.0
 | `:grafanacom_client_secret`                       | String        |                             | Grafana.com Authentication                                          |
 | `:grafanacom_scopes`                              | String        | `user:email`                | Grafana.com Authentication                                          |
 | `:grafanacom_allowed_organizations`               | String        |                             | Grafana.com Authentication                                          |
-| `:generic_oauth_name`                              | String        | `OAuth`                     | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_enabled`                           | True, False   | `false`                     | Enable Generic OAuth                                                | true, false
-| `:generic_oauth_allow_sign_up`                     | True, False   | `true`                      | <http://docs.grafana.org/auth/generic-oauth/>                         | true, false
-| `:generic_oauth_client_id`                         | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_client_secret`                     | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_scopes`                            | String        | `user:email`                | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_email_attribute_name`              | String        | `email:primary`             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_auth_url`                          | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_token_url`                         | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_api_url`                           | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_team_ids`                          | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_allowed_organizations`             | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_tls_skip_verify_insecure`          | True, False   | `false`                     | <http://docs.grafana.org/auth/generic-oauth/>                         | true, false
-| `:generic_oauth_tls_client_cert`                   | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_tls_client_key`                    | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_tls_client_ca`                     | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
-| `:generic_oauth_send_client_credentials_via_post`  | True, False   | `false`                     | <http://docs.grafana.org/auth/generic-oauth/>                         | true, false
+| `:generic_oauth_name`                             | String        | `OAuth`                     | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_enabled`                          | True, False   | `false`                     | Enable Generic OAuth                                                | true, false
+| `:generic_oauth_allow_sign_up`                    | True, False   | `true`                      | <http://docs.grafana.org/auth/generic-oauth/>                         | true, false
+| `:generic_oauth_client_id`                        | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_client_secret`                    | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_scopes`                           | String        | `user:email`                | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_email_attribute_name`             | String        | `email:primary`             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_auth_url`                         | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_token_url`                        | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_api_url`                          | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_team_ids`                         | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_allowed_organizations`            | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_tls_skip_verify_insecure`         | True, False   | `false`                     | <http://docs.grafana.org/auth/generic-oauth/>                         | true, false
+| `:generic_oauth_tls_client_cert`                  | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_tls_client_key`                   | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_tls_client_ca`                    | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
+| `:generic_oauth_send_client_credentials_via_post` | True, False   | `false`                     | <http://docs.grafana.org/auth/generic-oauth/>                         | true, false
+| `:generic_oauth_role_attribute_path`              | String        |                             | <http://docs.grafana.org/auth/generic-oauth/>                         |
 | `:basic_enabled`                                  | True, False   | `true`                      | Basic auth is enabled by default and works with the built in Grafana user password authentication system and LDAP authentication integration| true, false
 | `:proxy_enabled`                                  | True, False   | `false`                     | Defaults to false, but set to true to enable this feature (http://docs.grafana.org/auth/auth-proxy/)| true, false
 | `:proxy_header_name`                              | String        | `X-WEBAUTH-USER`            | HTTP Header name that will contain the username or email            |

--- a/resources/config_auth.rb
+++ b/resources/config_auth.rb
@@ -79,6 +79,7 @@ property  :generic_oauth_token_url,                        String,         defau
 property  :generic_oauth_api_url,                          String,         default: ''
 property  :generic_oauth_team_ids,                         String,         default: ''
 property  :generic_oauth_allowed_organizations,            String,         default: ''
+property  :generic_oauth_role_attribute_path,              String,         default: ''
 property  :generic_oauth_tls_skip_verify_insecure,         [true, false],  default: false
 property  :generic_oauth_tls_client_cert,                  String,         default: ''
 property  :generic_oauth_tls_client_key,                   String,         default: ''
@@ -156,6 +157,8 @@ action :install do
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_generic_oauth']['tls_client_ca'] << new_resource.generic_oauth_tls_client_ca.to_s unless new_resource.generic_oauth_tls_client_ca.nil?
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_generic_oauth']['send_client_credentials_via_post'] ||= '' unless new_resource.generic_oauth_send_client_credentials_via_post.nil?
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_generic_oauth']['send_client_credentials_via_post'] << new_resource.generic_oauth_send_client_credentials_via_post.to_s unless new_resource.generic_oauth_send_client_credentials_via_post.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_generic_oauth']['role_attribute_path'] ||= '' unless new_resource.generic_oauth_role_attribute_path.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_generic_oauth']['role_attribute_path'] << new_resource.generic_oauth_role_attribute_path.to_s unless new_resource.generic_oauth_role_attribute_path.nil?
 
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_github'] ||= {}
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_github']['enabled'] ||= '' unless new_resource.github_enabled.nil?

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -660,6 +660,9 @@ tls_client_ca = <%= @grafana['auth_generic_oauth']['tls_client_ca'] %>
 <% if @grafana['auth_generic_oauth']['send_client_credentials_via_post'] %>
 send_client_credentials_via_post = <%= @grafana['auth_generic_oauth']['send_client_credentials_via_post'] %>
 <% end %>
+<% if @grafana['auth_generic_oauth']['role_attribute_path'] %>
+role_attribute_path = <%= @grafana['auth_generic_oauth']['role_attribute_path'] %>
+<% end %>
 <% end %>
 #################################### Basic Auth ##########################
 <% if @grafana['auth_basic'] %>


### PR DESCRIPTION
- In Grafana 6.5+ the [role_attribute_path](https://grafana.com/docs/grafana/latest/auth/generic-oauth/\#role-mapping) is used to map user information to roles. Add this as an attribute

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
