### PR TITLE
Allow multiple LDAP group_mapping with the same group_dn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 8.4.0
+
+- Allow multiple LDAP mapping with the same group_dn
+
 ## 8.3.0
 
 - Adds role mapping to generic oauth resource <https://grafana.com/docs/grafana/latest/auth/generic-oauth/#role-mapping>

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures Grafana Server'
 source_url       'https://github.com/sous-chefs/grafana'
 issues_url       'https://github.com/sous-chefs/grafana/issues'
 chef_version     '>= 13.0'
-version          '8.3.0'
+version          '8.4.0'
 
 supports 'debian'
 supports 'ubuntu'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -24,7 +24,7 @@ property  :instance_name,       String,                   name_property: true
 property  :env_directory,       String,                   default: '/etc/default'
 property  :owner,               String,                   default: 'grafana'
 property  :group,               String,                   default: 'grafana'
-property  :restart_on_upgrade,  [TrueClass, FalseClass],  default: false
+property  :restart_on_upgrade,  [true, false],            default: false
 property  :conf_directory,      String,                   default: '/etc/grafana'
 property  :app_mode,            String,                   default: 'production', equal_to: %w(production development)
 property  :cookbook,            String,                   default: 'grafana'

--- a/resources/config_database.rb
+++ b/resources/config_database.rb
@@ -27,7 +27,7 @@ property  :password,          String,                   default: ''
 property  :max_idle_conn,     Integer,                  default: 2
 property  :max_open_conn,     Integer,                  default: 0
 property  :conn_max_lifetime, Integer,                  default: 14400
-property  :log_queries,       [TrueClass, FalseClass],  default: false
+property  :log_queries,       [true, false],            default: false
 property  :ssl_mode,          [Symbol, TrueClass, FalseClass], default: :disable, equal_to: [ :disable, :require, :'verify-full', true, false, :'skip-verify' ]
 property  :ca_cert_path,      String,                   default: ''
 property  :client_key_path,   String,                   default: ''

--- a/resources/config_ldap_group_mappings.rb
+++ b/resources/config_ldap_group_mappings.rb
@@ -27,12 +27,12 @@ property  :grafana_admin,                 [TrueClass, FalseClass],  default: fal
 property  :org_id,                        Integer,                  default: 1
 
 action :install do
-  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'] ||= {}
-  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'][new_resource.group_dn] ||= {}
-  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'][new_resource.group_dn]['org_role'] ||= '' unless new_resource.org_role.nil?
-  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'][new_resource.group_dn]['org_role'] = new_resource.org_role.to_s unless new_resource.org_role.nil?
-  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'][new_resource.group_dn]['grafana_admin'] ||= '' unless new_resource.grafana_admin.nil?
-  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'][new_resource.group_dn]['grafana_admin'] = new_resource.grafana_admin.to_s unless new_resource.grafana_admin.nil?
-  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'][new_resource.group_dn]['org_id'] ||= '' unless new_resource.org_id.nil?
-  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'][new_resource.group_dn]['org_id'] = new_resource.org_id.to_s unless new_resource.org_id.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'] ||= []
+  mapping = {
+    'group_dn' => new_resource.group_dn.to_s,
+    'org_role' => (new_resource.org_role || '').to_s,
+    'grafana_admin' => (new_resource.grafana_admin || '').to_s,
+    'org_id' => (new_resource.org_id || '').to_s,
+  }
+  node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'] << mapping
 end

--- a/resources/config_ldap_group_mappings.rb
+++ b/resources/config_ldap_group_mappings.rb
@@ -23,7 +23,7 @@
 property  :instance_name,                 String,                   name_property: true
 property  :group_dn,                      String,                   required: true
 property  :org_role,                      String,                   default: 'Viewer'
-property  :grafana_admin,                 [TrueClass, FalseClass],  default: false
+property  :grafana_admin,                 [true, false],            default: false
 property  :org_id,                        Integer,                  default: 1
 
 action :install do

--- a/resources/config_ldap_servers.rb
+++ b/resources/config_ldap_servers.rb
@@ -23,9 +23,9 @@
 property  :instance_name,                       String,                   name_property: true
 property  :host,                                String,                   required: true
 property  :port,                                Integer,                  default: 389
-property  :use_ssl,                             [TrueClass, FalseClass],  default: false
-property  :start_tls,                           [TrueClass, FalseClass],  default: false
-property  :ssl_skip_verify,                     [TrueClass, FalseClass],  default: false
+property  :use_ssl,                             [true, false],            default: false
+property  :start_tls,                           [true, false],            default: false
+property  :ssl_skip_verify,                     [true, false],            default: false
 property  :root_ca_cert,                        String
 property  :client_cert,                         String
 property  :client_key,                          String

--- a/resources/config_writer.rb
+++ b/resources/config_writer.rb
@@ -1,5 +1,5 @@
 property  :instance_name,       String,                   name_property: true
-property  :is_sensitive,        [TrueClass, FalseClass],  default: true
+property  :is_sensitive,        [true, false],            default: true
 property  :conf_directory,      String,                   default: '/etc/grafana'
 property  :config_file,         String,                   default: lazy { ::File.join(conf_directory, 'grafana.ini') }
 property  :config_file_ldap,    String,                   default: lazy { ::File.join(conf_directory, 'ldap.toml') }

--- a/templates/ldap.toml.erb
+++ b/templates/ldap.toml.erb
@@ -91,7 +91,7 @@ email = "<%= @ldap['servers_attributes_email'] %>"
 [[servers.group_mappings]]
 <% group.each do |k, v| %>
 <% next if v.nil? %>
-<%= k.to_s %>=<%= v.to_s %>
+<%= k.to_s %> = <%= v.to_s %>
 <% end %>
 
 <% end # group_mappings loop -%>

--- a/templates/ldap.toml.erb
+++ b/templates/ldap.toml.erb
@@ -86,18 +86,13 @@ email = "<%= @ldap['servers_attributes_email'] %>"
 
 # Map ldap groups to grafana org roles
 <% unless @ldap['group_mappings'].nil? %>
-<% @ldap['group_mappings'].each do | key, group | %>
+<% @ldap['group_mappings'].each do | group | %>
 
 [[servers.group_mappings]]
-group_dn = "<%= key %>"
-<% unless group['org_role'].nil? -%>
-org_role = "<%= group['org_role'] %>"
-<% end -%>
-<% unless group['org_id'].nil? -%>
-org_id = <%= group['org_id'] %>
-<% end -%>
-<% unless group['grafana_admin'].nil? -%>
-grafana_admin = <%= group['grafana_admin'] %>
-<% end -%>
+<% group.each do |k, v| %>
+<% next if v.nil? %>
+<%= k.to_s %>=<%= v.to_s %>
+<% end %>
+
 <% end # group_mappings loop -%>
 <% end # group_mappings unless -%>

--- a/templates/ldap.toml.erb
+++ b/templates/ldap.toml.erb
@@ -91,7 +91,7 @@ email = "<%= @ldap['servers_attributes_email'] %>"
 [[servers.group_mappings]]
 <% group.each do |k, v| %>
 <% next if v.nil? %>
-<%= k.to_s %> = <%= v.to_s %>
+<%= k.to_s %> = "<%= v.to_s %>"
 <% end %>
 
 <% end # group_mappings loop -%>


### PR DESCRIPTION
# Description

Allow multiple LDAP group_mapping with the same group_dn

## Issues Resolved

Grafana allows multiple ldap_group_mapping for the same group_dn so the same users can be part of multiple organizations

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
