### PR TITLE
Bugfix: fix value types in the ldap.toml config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 8.4.1
+
+- Bugfix: fix the value types in the ldap.toml file
+
 ## 8.4.0
 
 - Allow multiple LDAP mapping with the same group_dn

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures Grafana Server'
 source_url       'https://github.com/sous-chefs/grafana'
 issues_url       'https://github.com/sous-chefs/grafana/issues'
 chef_version     '>= 13.0'
-version          '8.4.0'
+version          '8.4.1'
 
 supports 'debian'
 supports 'ubuntu'

--- a/templates/ldap.toml.erb
+++ b/templates/ldap.toml.erb
@@ -89,10 +89,15 @@ email = "<%= @ldap['servers_attributes_email'] %>"
 <% @ldap['group_mappings'].each do | group | %>
 
 [[servers.group_mappings]]
-<% group.each do |k, v| %>
-<% next if v.nil? %>
-<%= k.to_s %> = "<%= v.to_s %>"
-<% end %>
-
+group_dn = "<%= group['group_dn'] %>"
+<% unless group['org_role'].nil? -%>
+org_role = "<%= group['org_role'] %>"
+<% end -%>
+<% unless group['org_id'].nil? -%>
+org_id = <%= group['org_id'] %>
+<% end -%>
+<% unless group['grafana_admin'].nil? -%>
+grafana_admin = <%= group['grafana_admin'] %>
+<% end -%>
 <% end # group_mappings loop -%>
 <% end # group_mappings unless -%>


### PR DESCRIPTION
# Description

Revert the changes made in the ldap.tml template because grafana requires specific value types

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
