### PR TITLE
Fix ldap.toml value types and add tests on that ldap config file content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of grafana.
 
+## 8.4.2
+
+- Bugfix: fix the value types in the ldap.toml file
+- Add tests to make sure ldap.toml file is matching requirements
+
 ## 8.4.1
 
 - Bugfix: fix the value types in the ldap.toml file

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -31,6 +31,7 @@ suites:
   - name: proxy
     run_list:
       - recipe[test::proxy]
+
   - name: plugins
     run_list:
       - recipe[test::plugins]

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures Grafana Server'
 source_url       'https://github.com/sous-chefs/grafana'
 issues_url       'https://github.com/sous-chefs/grafana/issues'
 chef_version     '>= 13.0'
-version          '8.4.1'
+version          '8.4.2'
 
 supports 'debian'
 supports 'ubuntu'

--- a/resources/config_ldap_group_mappings.rb
+++ b/resources/config_ldap_group_mappings.rb
@@ -29,10 +29,10 @@ property  :org_id,                        Integer,                  default: 1
 action :install do
   node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'] ||= []
   mapping = {
-    'group_dn' => new_resource.group_dn.to_s,
-    'org_role' => (new_resource.org_role || '').to_s,
-    'grafana_admin' => (new_resource.grafana_admin || '').to_s,
-    'org_id' => (new_resource.org_id || '').to_s,
+    'group_dn' => new_resource.group_dn,
+    'org_role' => new_resource.org_role,
+    'grafana_admin' => new_resource.grafana_admin,
+    'org_id' => new_resource.org_id,
   }
   node.run_state['sous-chefs'][new_resource.instance_name]['ldap']['group_mappings'] << mapping
 end

--- a/test/integration/ldap/ldap_spec.rb
+++ b/test/integration/ldap/ldap_spec.rb
@@ -20,6 +20,36 @@ describe file('/etc/grafana/grafana.ini') do
   it { should be_grouped_into 'grafana' }
 end
 
+describe toml('/etc/grafana/ldap.toml') do
+  its(['servers', 0, 'host']) { should eq '127.0.0.1' }
+  its(['servers', 0, 'port']) { should eq 389 }
+  its(['servers', 0, 'use_ssl']) { should eq false }
+  its(['servers', 0, 'start_tls']) { should eq false }
+  its(['servers', 0, 'ssl_skip_verify']) { should eq false }
+
+  its(['servers', 0, 'bind_dn']) { should eq 'cn=admin,dc=grafana,dc=org' }
+  its(['servers', 0, 'bind_password']) { should eq 'SuperSecretPassword' }
+
+  its(['servers', 0, 'search_filter']) { should eq '(cn=%s)' }
+  its(['servers', 0, 'search_base_dns', 0]) { should eq 'dc=grafana,dc=org' }
+
+  its(['servers', 0, 'attributes', 'name']) { should eq 'givenName' }
+  its(['servers', 0, 'attributes', 'surname']) { should eq 'sn' }
+  its(['servers', 0, 'attributes', 'username']) { should eq 'cn' }
+  its(['servers', 0, 'attributes', 'member_of']) { should eq 'memberOf' }
+  its(['servers', 0, 'attributes', 'email']) { should eq 'email' }
+
+  its(['servers', 0, 'group_mappings', 0, 'group_dn']) { should eq 'cn=admins,dc=grafana,dc=org' }
+  its(['servers', 0, 'group_mappings', 0, 'org_role']) { should eq 'Admin' }
+  its(['servers', 0, 'group_mappings', 0, 'org_id']) { should eq 1 }
+  its(['servers', 0, 'group_mappings', 0, 'grafana_admin']) { should eq true }
+
+  its(['servers', 0, 'group_mappings', 1, 'group_dn']) { should eq 'cn=readers,dc=grafana,dc=org' }
+  its(['servers', 0, 'group_mappings', 1, 'org_role']) { should eq 'Viewer' }
+  its(['servers', 0, 'group_mappings', 1, 'org_id']) { should eq 1 }
+  its(['servers', 0, 'group_mappings', 1, 'grafana_admin']) { should eq false }
+end
+
 describe service('grafana-server') do
   it { should be_enabled }
   it { should be_running }


### PR DESCRIPTION
# Description

The chef custom resource already has defined default values so we don't need to cast everything as string. The current code is causing issues when the boolean values are false.
This bug was created in a previous PR merged last week. Tests were added to make sure the ldap.toml config file is matching grafana requirements

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
