### PR TITLE
Add AzureAD Auth provider option (grafana 6.7)

### DIFF
--- a/documentation/grafana_config_auth.md
+++ b/documentation/grafana_config_auth.md
@@ -17,13 +17,13 @@ Introduced: v4.0.0
 ## Properties
 
 | Name                                              | Type          |  Default                    | Description                                                         | Allowed Values
-| ------------------------------------------------ | -------------  | --------------------------- | ------------------------------------------------------------------  | --------------- |
+| ------------------------------------------------  | ------------- | --------------------------- | ------------------------------------------------------------------  | --------------- |
 | `login_cookie_name`                               | String        | `nil`                       | Session cookie name,  default changed at Grafana 6.0.0 so programatically determining default in install action |
 | `disable_login_form`                              | True, False   | `false`                     | Set to true to disable (hide) the login form, useful if you use OAuth | true, false
 | `disable_signout_menu`                            | True, False   | `false`                     | Set to true to disable the signout link in the side menu. useful if you use auth.proxy | true, false
 | `:signout_redirect_url`                           | String        |                             | URL to redirect the user to after sign out                          |
 | `:oauth_auto_login`                               | True, False   | `false`                     | Set to true to attempt login with OAuth automatically, skipping the login screen| true, false
-| `:login_maximum_lifetime_days`                     | Integer       | `nil`                       | The number of days to set the session cookie lifetime to if auth enabled |
+| `:login_maximum_lifetime_days`                    | Integer       | `nil`                       | The number of days to set the session cookie lifetime to if auth enabled |
 | `:anonymous_enabled`                              | True, False   | `false`                     | enable anonymous access                                             | true, false
 | `:anonymous_org_name`                             | String        | `Main Org.`                 | specify organization name that should be used for unauthenticated users|
 | `:anonymous_org_role`                             | String        | `Viewer`                    | specify role for unauthenticated users                              |
@@ -91,7 +91,7 @@ Introduced: v4.0.0
 | `:proxy_header_name`                              | String        | `X-WEBAUTH-USER`            | HTTP Header name that will contain the username or email            |
 | `:proxy_header_property`                          | String        | `username`                  | HTTP Header property, defaults to `username` but can also be `email`|
 | `:proxy_auto_sign_up`                             | True, False   |  `true`                     | Set to `true` to enable auto sign up of users who do not exist in Grafana DB. Defaults to `true`.| true, false
-| `:proxy_ldap_sync_ttl`                            |  Integer      | `60`                        | If combined with Grafana LDAP integration define sync interval      |
+| `:proxy_ldap_sync_ttl`                            | Integer       | `60`                        | If combined with Grafana LDAP integration define sync interval      |
 | `:proxy_whitelist`                                | String        |                             | Limit where auth proxy requests come from by configuring a list of IP addresses|
 | `:proxy_headers`                                  | String        |                             | Optionally define more headers to sync other user attributes        |
 | `:ldap_enabled`                                   | True, False   | `false`                     | Set to `true` to enable LDAP integration (http://docs.grafana.org/auth/ldap/)| true, false

--- a/documentation/grafana_config_auth_azuread.md
+++ b/documentation/grafana_config_auth_azuread.md
@@ -1,0 +1,28 @@
+[back to resource list](https://github.com/sous-chefs/grafana#resources)
+
+---
+
+# grafana_config_auth_azuread
+
+Configures the auth.azuread section of the configuration <https://grafana.com/docs/grafana/latest/auth/azuread/>
+
+Introduced: v6.7.0
+
+## Actions
+
+`:create`
+
+## Properties
+
+| Name                                              | Type          |  Default                    | Description                                                         | Allowed Values
+| ------------------------------------------------  | ------------- | --------------------------- | ------------------------------------------------------------------  | --------------- |
+| `:azuread_name`                                   | String        | `AzureAD`                   | <https://grafana.com/docs/grafana/latest/auth/azuread/>             |
+| `:azuread_enabled`                                | True, False   | `false`                     | Enable AzureAD Auth                                                 | true, false
+| `:azuread_allow_sign_up`                          | True, False   | `true`                      | <https://grafana.com/docs/grafana/latest/auth/azuread/>             | true, false
+| `:azuread_client_id`                              | String        |                             | <https://grafana.com/docs/grafana/latest/auth/azuread/>             |
+| `:azuread_client_secret`                          | String        |                             | <https://grafana.com/docs/grafana/latest/auth/azuread/>             |
+| `:azuread_scopes`                                 | String        | `openid email profile`      | <https://grafana.com/docs/grafana/latest/auth/azuread/>             |
+| `:azuread_auth_url`                               | String        |                             | <https://grafana.com/docs/grafana/latest/auth/azuread/>             |
+| `:azuread_token_url`                              | String        |                             | <https://grafana.com/docs/grafana/latest/auth/azuread/>             |
+| `:azuread_allowed_domains`                        | String        |                             | <https://grafana.com/docs/grafana/latest/auth/azuread/>             |
+| `:azuread_allowed_roles`                          | String        |                             | <https://grafana.com/docs/grafana/latest/auth/azuread/>             |

--- a/resources/config_auth_azuread.rb
+++ b/resources/config_auth_azuread.rb
@@ -1,0 +1,54 @@
+# Cookbook:: grafana
+# Resource:: config_auth_azuread
+#
+# Copyright:: 2018, Sous Chefs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Configures the installed grafana instance
+
+property  :instance_name,                                  String,         name_property: true
+property  :azuread_name,                                   String,         default: 'AzureAD'
+property  :azuread_enabled,                                [true, false],  default: false
+property  :azuread_allow_sign_up,                          [true, false],  default: true
+property  :azuread_client_id,                              String,         default: ''
+property  :azuread_client_secret,                          String,         default: ''
+property  :azuread_scopes,                                 String,         default: 'openid email profile'
+property  :azuread_auth_url,                               String,         default: ''
+property  :azuread_token_url,                              String,         default: ''
+property  :azuread_allowed_domains,                        String,         default: ''
+property  :azuread_allowed_groups,                         String,         default: ''
+
+action :install do
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread'] ||= {}
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['name'] ||= '' unless new_resource.azuread_name.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['name'] << new_resource.azuread_name.to_s unless new_resource.azuread_name.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['enabled'] ||= '' unless new_resource.azuread_enabled.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['enabled'] << new_resource.azuread_enabled.to_s unless new_resource.azuread_enabled.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['allow_sign_up'] ||= '' unless new_resource.azuread_allow_sign_up.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['allow_sign_up'] << new_resource.azuread_allow_sign_up.to_s unless new_resource.azuread_allow_sign_up.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['client_id'] ||= '' unless new_resource.azuread_client_id.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['client_id'] << new_resource.azuread_client_id.to_s unless new_resource.azuread_client_id.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['client_secret'] ||= '' unless new_resource.azuread_client_secret.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['client_secret'] << new_resource.azuread_client_secret.to_s unless new_resource.azuread_client_secret.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['scopes'] ||= '' unless new_resource.azuread_scopes.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['scopes'] << new_resource.azuread_scopes.to_s unless new_resource.azuread_scopes.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['auth_url'] ||= '' unless new_resource.azuread_auth_url.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['auth_url'] << new_resource.azuread_auth_url.to_s unless new_resource.azuread_auth_url.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['token_url'] ||= '' unless new_resource.azuread_token_url.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['token_url'] << new_resource.azuread_token_url.to_s unless new_resource.azuread_token_url.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['allowed_domains'] ||= '' unless new_resource.azuread_allowed_domains.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['allowed_domains'] << new_resource.azuread_allowed_domains.to_s unless new_resource.azuread_allowed_domains.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['allowed_groups'] ||= '' unless new_resource.azuread_allowed_groups.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['auth_azuread']['allowed_groups'] << new_resource.azuread_allowed_groups.to_s unless new_resource.azuread_allowed_groups.nil?
+end

--- a/templates/grafana.ini.erb
+++ b/templates/grafana.ini.erb
@@ -715,6 +715,40 @@ config_file = <%= @grafana['auth_ldap']['config_file'] %>
 allow_sign_up = <%= @grafana['auth_ldap']['allow_sign_up'] %>
 <% end %>
 <% end %>
+#################################### Auth AzureAD #######################
+<% if @grafana['auth_azuread'] %>
+[auth.azuread]
+<% if @grafana['auth_azuread']['name'] %>
+name = <%= @grafana['auth_azuread']['name'] %>
+<% end %>
+<% if @grafana['auth_azuread']['enabled'] %>
+enabled = <%= @grafana['auth_azuread']['enabled'] %>
+<% end %>
+<% if @grafana['auth_azuread']['allow_sign_up'] %>
+allow_sign_up = <%= @grafana['auth_azuread']['allow_sign_up'] %>
+<% end %>
+<% if @grafana['auth_azuread']['client_id'] %>
+client_id = <%= @grafana['auth_azuread']['client_id'] %>
+<% end %>
+<% if @grafana['auth_azuread']['client_secret'] %>
+client_secret = <%= @grafana['auth_azuread']['client_secret'] %>
+<% end %>
+<% if @grafana['auth_azuread']['scopes'] %>
+scopes = <%= @grafana['auth_azuread']['scopes'] %>
+<% end %>
+<% if @grafana['auth_azuread']['auth_url'] %>
+auth_url = <%= @grafana['auth_azuread']['auth_url'] %>
+<% end %>
+<% if @grafana['auth_azuread']['token_url'] %>
+token_url = <%= @grafana['auth_azuread']['token_url'] %>
+<% end %>
+<% if @grafana['auth_azuread']['allowed_domains'] %>
+allowed_domains = <%= @grafana['auth_azuread']['allowed_domains'] %>
+<% end %>
+<% if @grafana['auth_azuread']['allowed_groups'] %>
+allowed_groups = <%= @grafana['auth_azuread']['allowed_groups'] %>
+<% end %>
+<% end %>
 #################################### SMTP / Emailing #####################
 <% if @grafana['smtp'] %>
 [smtp]


### PR DESCRIPTION
# Description

Adds the AzureAD auth provider to the auth configuration to support the new provider in Grafana 6.7.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
