### PR TITLE
Remove Chef Sleep from tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## Unreleased
+
+- Fixed tests to not require `chef_sleep`
+
 ## 9.1.0
 
 - Add in support for `min_refresh_interval` configuration to dashboard config.

--- a/test/fixtures/cookbooks/test/recipes/azuread.rb
+++ b/test/fixtures/cookbooks/test/recipes/azuread.rb
@@ -22,7 +22,7 @@ grafana_config_writer 'Grafana' do
   sensitive false
 end
 
-# # Tests are failing as the server has not fully become available when tests run
-# chef_sleep 'Sleep so inspec tests pass' do
-#   seconds 25
-# end
+# Tests are failing as the server has not fully become available when tests run
+chef_sleep 'Sleep so inspec tests pass' do
+  seconds 25
+end

--- a/test/fixtures/cookbooks/test/recipes/azuread.rb
+++ b/test/fixtures/cookbooks/test/recipes/azuread.rb
@@ -22,7 +22,7 @@ grafana_config_writer 'Grafana' do
   sensitive false
 end
 
-# Tests are failing as the server has not fully become available when tests run
-chef_sleep 'Sleep so inspec tests pass' do
-  seconds 25
-end
+# # Tests are failing as the server has not fully become available when tests run
+# chef_sleep 'Sleep so inspec tests pass' do
+#   seconds 25
+# end

--- a/test/integration/configure/configure_spec.rb
+++ b/test/integration/configure/configure_spec.rb
@@ -91,12 +91,17 @@ describe json(command: "curl http://localhost:3000/api/datasources --header #{cu
   its([1, 'database']) { should eq 'metrics' }
 end
 
-describe json(command: "curl http://localhost:3000/api/dashboards/db/sample-dashboard --header #{curl_auth_headers}") do
+describe json(content: http('http://localhost:3000/api/dashboards/db/sample-dashboard', auth: { user: 'admin', pass: 'admin' },
+  method: 'GET',
+  headers: { 'Content-Type' => 'application/json' }).body) do
   its(%w(meta slug)) { should eq 'sample-dashboard' }
 end
 
 # TODO: Find a way to validate the dashboard is in the right folder
-describe json(command: "curl http://localhost:3000/api/dashboards/db/sample-dashboard-folder --header #{curl_auth_headers}") do
+
+describe json(content: http('http://localhost:3000/api/dashboards/db/sample-dashboard-folder', auth: { user: 'admin', pass: 'admin' },
+  method: 'GET',
+  headers: { 'Content-Type' => 'application/json' }).body) do
   its(%w(meta slug)) { should eq 'sample-dashboard-folder' }
 end
 
@@ -112,7 +117,10 @@ describe http('http://localhost:3000/api/folders', headers: auth_headers) do
   end
 end
 
-describe json(content: http('http://localhost:3000/api/admin/settings', auth: { user: 'admin', pass: 'admin' }, params: { format: 'html' }, method: 'GET', headers: { 'Content-Type' => 'application/json' }).body) do
+describe json(content: http('http://localhost:3000/api/admin/settings', auth: { user: 'admin', pass: 'admin' },
+  params: { format: 'html' },
+  method: 'GET',
+  headers: { 'Content-Type' => 'application/json' }).body) do
   its(%w(dashboards min_refresh_interval)) { should eq '3s' }
   its(%w(dashboards versions_to_keep)) { should eq '2' }
 end


### PR DESCRIPTION
# Description

This moves tests to using the http method instead of curl, which stops us from from needing chef_sleep

Signed-off-by: Jason Field <jason@avon-lea.co.uk>
## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
