### PR TITLE
Feature/support https and url_path_prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## Unreleased
+
+- Added support for HTTPS endpoint
+
 ## 9.2.1
 
 - Fixed tests to not require `chef_sleep`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of grafana.
 ## Unreleased
 
 - Added support for HTTPS endpoint
+- Added support for endpoints with url_path_prefix
 
 ## 9.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of grafana.
 
 - Added support for HTTPS endpoint
 - Added support for endpoints with url_path_prefix
+- Fixed url_path_prefix property definition in resources
 
 ## 9.3.0 - 2020-08-19
 

--- a/documentation/grafana_dashboard.md
+++ b/documentation/grafana_dashboard.md
@@ -20,6 +20,7 @@ This resource currently makes an assumption that the name used in invocation mat
 | --------------------- | ----------- | ------------- | --------------------------------------------------------- | --------------- |
 | `host`                |  String     | `localhost`   | The host grafana is running on|
 | `port`                |  Integer    | `3000`        | The port grafana is running on|
+| `url_path_prefix`     |  String     | nil           | The url_path_prefix grafana is available from when running behind the proxy (ex. '/grafana')|
 | `admin_user`          |  String     | `admin`       | A grafana user with admin privileges|
 | `admin_password`      |  String     | `admin`       | The grafana user's password|
 | `auth_proxy_header`   | String      | nil           | The HTTP authentication header used when `auth.proxy.enabled=true`. See [grafana_config_auth:proxy_header_name](grafana_config_auth.md)|

--- a/documentation/grafana_dashboard_template.md
+++ b/documentation/grafana_dashboard_template.md
@@ -20,6 +20,7 @@ This resource currently makes the same assumptions that grafana_dashboard does s
 | --------------------- | ----------- | ------------------------- | --------------------------------------------------------- | --------------- |
 | `host`                |  String     | `localhost`               | The host grafana is running on|
 | `port`                |  Integer    | `3000`                    | The port grafana is running on|
+| `url_path_prefix`     |  String     | nil                       | The url_path_prefix grafana is available from when running behind the proxy (ex. '/grafana')|
 | `admin_user`          |  String     | `admin`                   | A grafana user with admin privileges|
 | `admin_password`      |  String     | `admin`                   | The grafana user's password|
 | `auth_proxy_header`   |  String     | nil                       | The HTTP authentication header used when `auth.proxy.enabled=true`. See [grafana_config_auth:proxy_header_name](grafana_config_auth.md)|

--- a/documentation/grafana_dashboards_backup.md
+++ b/documentation/grafana_dashboards_backup.md
@@ -16,6 +16,7 @@ This resource will allow you to backup all Grafana dashboards to a folder by org
 | --------------------- | ----------- | ------------- | --------------------------------------------------------- | --------------- |
 | `host`                |  String     | `localhost`   | The host grafana is running on|
 | `port`                |  Integer    | `3000`        | The port grafana is running on|
+| `url_path_prefix`     |  String     | nil           | The url_path_prefix grafana is available from when running behind the proxy (ex. '/grafana')|
 | `admin_user`          |  String     | `admin`       | A grafana user with admin privileges|
 | `admin_password`      |  String     | `admin`       | The grafana user's password|
 | `auth_proxy_header`   | String      | nil           | The HTTP authentication header used when `auth.proxy.enabled=true`. See [grafana_config_auth:proxy_header_name](grafana_config_auth.md)|

--- a/documentation/grafana_datasorces_backup.md
+++ b/documentation/grafana_datasorces_backup.md
@@ -16,6 +16,7 @@ This resource will allow you to backup all Grafana datasources to a folder by or
 | --------------------- | ----------- | ------------- | --------------------------------------------------------- | --------------- |
 | `host`                |  String     | `localhost`   | The host grafana is running on|
 | `port`                |  Integer    | `3000`        | The port grafana is running on|
+| `url_path_prefix`     |  String     | nil           | The url_path_prefix grafana is available from when running behind the proxy (ex. '/grafana')|
 | `admin_user`          |  String     | `admin`       | A grafana user with admin privileges|
 | `admin_password`      |  String     | `admin`       | The grafana user's password|
 | `auth_proxy_header`   |  String     | nil           | The HTTP authentication header used when `auth.proxy.enabled=true`. See [grafana_config_auth:proxy_header_name](grafana_config_auth.md)|

--- a/documentation/grafana_datasource.md
+++ b/documentation/grafana_datasource.md
@@ -18,6 +18,7 @@ You can control Grafana dataSources via the `grafana_datasource`. Due to the var
 | --------------------- | ----------- | ------------- | --------------------------------------------------------- | --------------- |
 | `host`                | String      | `localhost`   | The host grafana is running on|
 | `port`                | Integer     | `3000`        | The port grafana is running on|
+| `url_path_prefix`     | String      | nil           | The url_path_prefix grafana is available from when running behind the proxy (ex. '/grafana')|
 | `admin_user`          | String      | `admin`       | A grafana user with admin privileges|
 | `admin_password`      | String      | `admin`       | The grafana user's password|
 | `auth_proxy_header`   | String      | nil           | The HTTP authentication header used when `auth.proxy.enabled=true`. See [grafana_config_auth:proxy_header_name](grafana_config_auth.md)|

--- a/documentation/grafana_folder.md
+++ b/documentation/grafana_folder.md
@@ -20,6 +20,7 @@ More information about creating Grafana folder via the HTTP API can be found [he
 | --------------------- | ----------- | ------------- | --------------------------------------------------------- | --------------- |
 | `host`                |  String     | `localhost`   | The host grafana is running on|
 | `port`                |  Integer    | `3000`        | The port grafana is running on|
+| `url_path_prefix`     |  String     | nil           | The url_path_prefix grafana is available from when running behind the proxy (ex. '/grafana')|
 | `admin_user`          |  String     | `admin`       | A grafana user with admin privileges|
 | `admin_password`      |  String     | `admin`       | The grafana user's password|
 | `auth_proxy_header`   | String      | nil           | The HTTP authentication header used when `auth.proxy.enabled=true`. See [grafana_config_auth:proxy_header_name](grafana_config_auth.md)|

--- a/documentation/grafana_organization.md
+++ b/documentation/grafana_organization.md
@@ -20,6 +20,7 @@ More information about creating Grafana organizations via the HTTP API can be fo
 | --------------------- | ----------- | ------------- | --------------------------------------------------------- | --------------- |
 | `host`                | String      | `localhost`   | The host grafana is running on|
 | `port`                | Integer     | `3000`        | The port grafana is running on|
+| `url_path_prefix`     | String      | nil           | The url_path_prefix grafana is available from when running behind the proxy (ex. '/grafana')|
 | `admin_user`          | String      | `admin`       | A grafana user with admin privileges|
 | `admin_password`      | String      | `admin`       | The grafana user's password|
 | `auth_proxy_header`   | String      | nil           | The HTTP authentication header used when `auth.proxy.enabled=true`. See [grafana_config_auth:proxy_header_name](grafana_config_auth.md)|

--- a/documentation/grafana_user.md
+++ b/documentation/grafana_user.md
@@ -20,6 +20,7 @@ More information about creating Grafana users via the HTTP API can be found at <
 | --------------------- | ----------- | ------------- | --------------------------------------------------------- | --------------- |
 | `host`                | String      | `localhost`   | The host grafana is running on|
 | `port`                | Integer     | `3000`        | The port grafana is running on|
+| `url_path_prefix`     | String      | nil           | The url_path_prefix grafana is available from when running behind the proxy (ex. '/grafana')|
 | `admin_user`          | String      | `admin`       | A grafana user with admin privileges|
 | `admin_password`      | String      | `admin`       | The grafana user's password|
 | `auth_proxy_header`   | String      | nil           | The HTTP authentication header used when `auth.proxy.enabled=true`. See [grafana_config_auth:proxy_header_name](grafana_config_auth.md)|

--- a/libraries/api_helper.rb
+++ b/libraries/api_helper.rb
@@ -13,6 +13,7 @@ module GrafanaCookbook
     def login(host, port, user, password)
       http = Net::HTTP.new(host, port)
       request = Net::HTTP::Post.new('/login')
+      http.use_ssl = true if port == 443
       request.add_field('Content-Type', 'application/json;charset=utf-8')
       request.body = { 'User' => user, 'email' => '', 'Password' => password }.to_json
 
@@ -61,6 +62,7 @@ module GrafanaCookbook
     # +grafana_options+:: A hash of the host, port, user, and password as well as request parameters
     def do_request(grafana_options, payload = nil)
       http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
+      http.use_ssl = true if port == 443
       request = case grafana_options[:method]
                 when 'Patch'
                   Net::HTTP::Patch.new(grafana_options[:endpoint])

--- a/libraries/api_helper.rb
+++ b/libraries/api_helper.rb
@@ -10,9 +10,9 @@ module GrafanaCookbook
     # +port+:: The port grafana is running on
     # +user+:: A grafana user with admin privileges
     # +password+:: The grafana user's password
-    def login(host, port, user, password)
+    def login(host, port, url_path_prefix, user, password)
       http = Net::HTTP.new(host, port)
-      request = Net::HTTP::Post.new('/login')
+      request = Net::HTTP::Post.new(url_path_prefix.to_s + '/login')
       http.use_ssl = true if port == 443
       request.add_field('Content-Type', 'application/json;charset=utf-8')
       request.body = { 'User' => user, 'email' => '', 'Password' => password }.to_json
@@ -63,22 +63,23 @@ module GrafanaCookbook
     def do_request(grafana_options, payload = nil)
       http = Net::HTTP.new(grafana_options[:host], grafana_options[:port])
       http.use_ssl = true if port == 443
+      endpoint = grafana_options[:url_path_prefix].to_s + grafana_options[:endpoint]
       request = case grafana_options[:method]
                 when 'Patch'
-                  Net::HTTP::Patch.new(grafana_options[:endpoint])
+                  Net::HTTP::Patch.new(endpoint)
                 when 'Post'
-                  Net::HTTP::Post.new(grafana_options[:endpoint])
+                  Net::HTTP::Post.new(endpoint)
                 when 'Put'
-                  Net::HTTP::Put.new(grafana_options[:endpoint])
+                  Net::HTTP::Put.new(endpoint)
                 when 'Delete'
-                  Net::HTTP::Delete.new(grafana_options[:endpoint])
+                  Net::HTTP::Delete.new(endpoint)
                 else
-                  Net::HTTP::Get.new(grafana_options[:endpoint])
+                  Net::HTTP::Get.new(endpoint)
                 end
       if grafana_options[:auth_proxy_header]
         request.add_field(grafana_options[:auth_proxy_header], grafana_options[:user])
       else
-        session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:user], grafana_options[:password])
+        session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:url_path_prefix], grafana_options[:user], grafana_options[:password])
         request.add_field('Cookie', "grafana_user=#{grafana_options[:user]}; #{GrafanaCookbook::CookieHelper.cookie_name}=#{session_id};")
       end
       request.add_field('Content-Type', 'application/json;charset=utf-8;')

--- a/libraries/user_api.rb
+++ b/libraries/user_api.rb
@@ -29,7 +29,7 @@ module GrafanaCookbook
     def update_user_password(user, grafana_options)
       # Test user login with provided password.
       # If it succeeds, no need to update password
-      user_session_id = login(grafana_options[:host], grafana_options[:port], user[:login], user[:password])
+      user_session_id = login(grafana_options[:host], grafana_options[:port], grafana_options[:url_path_prefix], user[:login], user[:password])
       return if user_session_id
 
       # If it fails, that means we have to change password

--- a/resources/dashboard.rb
+++ b/resources/dashboard.rb
@@ -21,6 +21,7 @@
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
+property :url_path_prefix, [String, nil], default: nil
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :dashboard,      Hash,     default: {}
@@ -37,6 +38,7 @@ action :create do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -86,6 +88,7 @@ action :update do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -104,6 +107,7 @@ action :delete do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,

--- a/resources/dashboard.rb
+++ b/resources/dashboard.rb
@@ -21,7 +21,7 @@
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
-property :url_path_prefix, [String, nil], default: nil
+property :url_path_prefix, String
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :dashboard,      Hash,     default: {}

--- a/resources/dashboard_template.rb
+++ b/resources/dashboard_template.rb
@@ -1,5 +1,6 @@
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
+property :url_path_prefix,    [String, nil], default: nil
 property :admin_user,         String,   default: 'admin'
 property :admin_password,     String,   default: 'admin'
 property :auth_proxy_header,  String
@@ -29,6 +30,7 @@ action :delete do
   grafana_dashboard new_resource.name do
     host new_resource.host
     port new_resource.port
+    url_path_prefix new_resource.url_path_prefix
     auth_proxy_header new_resource.auth_proxy_header
     admin_user new_resource.admin_user
     admin_password new_resource.admin_password
@@ -65,6 +67,7 @@ action_class do
     grafana_dashboard new_resource.name do
       host new_resource.host
       port new_resource.port
+      url_path_prefix new_resource.url_path_prefix
       auth_proxy_header new_resource.auth_proxy_header
       admin_user new_resource.admin_user
       admin_password new_resource.admin_password

--- a/resources/dashboard_template.rb
+++ b/resources/dashboard_template.rb
@@ -1,6 +1,6 @@
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
-property :url_path_prefix,    [String, nil], default: nil
+property :url_path_prefix,    String
 property :admin_user,         String,   default: 'admin'
 property :admin_password,     String,   default: 'admin'
 property :auth_proxy_header,  String

--- a/resources/dashboards_backup.rb
+++ b/resources/dashboards_backup.rb
@@ -1,5 +1,6 @@
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
+property :url_path_prefix,    [String, nil], default: nil
 property :admin_user,         String,   default: 'admin'
 property :admin_password,     String,   default: 'admin'
 property :auth_proxy_header,  String
@@ -17,6 +18,7 @@ action :create do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,

--- a/resources/dashboards_backup.rb
+++ b/resources/dashboards_backup.rb
@@ -1,6 +1,6 @@
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
-property :url_path_prefix,    [String, nil], default: nil
+property :url_path_prefix,    String
 property :admin_user,         String,   default: 'admin'
 property :admin_password,     String,   default: 'admin'
 property :auth_proxy_header,  String

--- a/resources/datasource.rb
+++ b/resources/datasource.rb
@@ -21,6 +21,7 @@
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
+property :url_path_prefix, [String, nil], default: nil
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :datasource,     Hash,     default: {}
@@ -36,6 +37,7 @@ action :create do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -67,6 +69,7 @@ action :update do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -112,6 +115,7 @@ action :delete do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,

--- a/resources/datasource.rb
+++ b/resources/datasource.rb
@@ -21,7 +21,7 @@
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
-property :url_path_prefix, [String, nil], default: nil
+property :url_path_prefix, String
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :datasource,     Hash,     default: {}

--- a/resources/datasources_backup.rb
+++ b/resources/datasources_backup.rb
@@ -1,5 +1,6 @@
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
+property :url_path_prefix,    [String, nil], default: nil
 property :admin_user,         String,   default: 'admin'
 property :admin_password,     String,   default: 'admin'
 property :auth_proxy_header,  String
@@ -17,6 +18,7 @@ action :create do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,

--- a/resources/datasources_backup.rb
+++ b/resources/datasources_backup.rb
@@ -1,6 +1,6 @@
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
-property :url_path_prefix,    [String, nil], default: nil
+property :url_path_prefix,    String
 property :admin_user,         String,   default: 'admin'
 property :admin_password,     String,   default: 'admin'
 property :auth_proxy_header,  String

--- a/resources/folder.rb
+++ b/resources/folder.rb
@@ -1,7 +1,7 @@
 # To learn more about Custom Resources, see https://docs.chef.io/custom_resources.html
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
-property :url_path_prefix, [String, nil], default: nil
+property :url_path_prefix, String
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :folder,         Hash,     default: {}

--- a/resources/folder.rb
+++ b/resources/folder.rb
@@ -1,6 +1,7 @@
 # To learn more about Custom Resources, see https://docs.chef.io/custom_resources.html
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
+property :url_path_prefix, [String, nil], default: nil
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :folder,         Hash,     default: {}
@@ -17,6 +18,7 @@ action :create do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -51,6 +53,7 @@ action :update do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -92,6 +95,7 @@ action :delete do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,

--- a/resources/organization.rb
+++ b/resources/organization.rb
@@ -21,6 +21,7 @@
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
+property :url_path_prefix, [String, nil], default: nil
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :organization,   Hash,     default: {}
@@ -35,6 +36,7 @@ action :create do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -63,6 +65,7 @@ action :update do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -98,6 +101,7 @@ action :delete do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,

--- a/resources/organization.rb
+++ b/resources/organization.rb
@@ -21,7 +21,7 @@
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
-property :url_path_prefix, [String, nil], default: nil
+property :url_path_prefix, String
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :organization,   Hash,     default: {}

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -21,7 +21,7 @@
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
-property :url_path_prefix, [String, nil], default: nil
+property :url_path_prefix, String
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :user,           Hash,     default: {}

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -21,6 +21,7 @@
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
+property :url_path_prefix, [String, nil], default: nil
 property :admin_user,     String,   default: 'admin'
 property :admin_password, String,   default: 'admin'
 property :user,           Hash,     default: {}
@@ -36,6 +37,7 @@ action :create do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -79,6 +81,7 @@ action :update do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,
@@ -129,6 +132,7 @@ action :delete do
   grafana_options = {
     host: new_resource.host,
     port: new_resource.port,
+    url_path_prefix: new_resource.url_path_prefix,
     user: new_resource.admin_user,
     password: new_resource.admin_password,
     auth_proxy_header: new_resource.auth_proxy_header,


### PR DESCRIPTION
# Description

These changes allow cookbook usage against remote Grafana services secured by HTTPS and available within the subdirectory behind a proxy. 

## Issues Resolved

Fixes #376 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
