### PR TITLE
Add cookie_samesite parameter to config_security resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of grafana.
 
+## Unreleased
+
+- Added support for cookie_samesite settings (#383)
+
 ## 9.4.1 - 2020-08-31
 
 - Bugfix for undefined port variable (#381)

--- a/documentation/grafana_config_security.md
+++ b/documentation/grafana_config_security.md
@@ -25,6 +25,7 @@ Introduced: v4.0.0
 | `disable_brute_force_login_protection`  | true, false | `false`                     | disable protection against brute force login attempts.  | true, false
 | `allow_embedding`                       | true, false | `false`                     | Allows grafana to be embedded in an iframe              | true, false
 | `cookie_secure`                         | true, false | `false`                     | Secures cookies if running behind https                 | true, false
+| `cookie_samesite`                       | String      | `lax`                       | Sets `SameSite` cookie and Prevents the browser from sending this cookie along with CSS attacks.|
 
 ## Examples
 

--- a/resources/config_security.rb
+++ b/resources/config_security.rb
@@ -30,6 +30,7 @@ property  :data_source_proxy_whitelist,           String,         default: ''
 property  :disable_brute_force_login_protection,  [true, false],  default: false
 property  :allow_embedding,                       [true, false],  default: false
 property  :cookie_secure,                         [true, false],  default: false
+property  :cookie_samesite,                       String,         default: 'lax'
 
 action :install do
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['security'] ||= {}
@@ -55,4 +56,6 @@ action :install do
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['security']['allow_embedding'] << new_resource.allow_embedding.to_s unless new_resource.allow_embedding.nil?
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['security']['cookie_secure'] ||= '' unless new_resource.cookie_secure.nil?
   node.run_state['sous-chefs'][new_resource.instance_name]['config']['security']['cookie_secure'] << new_resource.cookie_secure.to_s unless new_resource.cookie_secure.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['security']['cookie_samesite'] ||= '' unless new_resource.cookie_samesite.nil?
+  node.run_state['sous-chefs'][new_resource.instance_name]['config']['security']['cookie_samesite'] << new_resource.cookie_samesite.to_s unless new_resource.cookie_samesite.nil?
 end

--- a/test/integration/configure/configure_spec.rb
+++ b/test/integration/configure/configure_spec.rb
@@ -43,6 +43,13 @@ describe json(command: "curl http://localhost:3000/api/org --header #{curl_auth_
   its('id') { should eq 2 }
 end
 
+auth_body = '{"user":"admin","password":"admin"}'
+describe http('http://localhost:3000/login', method: 'POST', headers: { 'Content-Type' => 'application/json' }, data: auth_body) do
+  its('status') { should eq 200 }
+  its('body') { should cmp /Logged in/ }
+  its('headers.set-cookie') { should cmp /SameSite=Lax/ }
+end
+
 describe http('http://localhost:3000/api/users', headers: auth_headers) do
   its('status') { should eq 200 }
 


### PR DESCRIPTION
# Description

This adds the ability for configuring the [https://grafana.com/docs/grafana/latest/administration/configuration/#cookie_samesite](cookie_samesite) setting. 

## Issues Resolved

N/A

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
