### PR TITLE
Align documentation with implemenation

### DIFF
--- a/documentation/grafana_config_ldap_group_mappings.md
+++ b/documentation/grafana_config_ldap_group_mappings.md
@@ -10,12 +10,13 @@ Introduced: v4.0.0
 
 ## Actions
 
-`:create`
+`:install`
 
 ## Properties
 
 | Name              | Type          |  Default                 | Description                                                               | Allowed Values
 | ----------------- | ------------- | ------------------------ | ------------------------------------------------------------------------- | --------------- |
+| `instance_name`   | String        |                          | Name Property, name of the instance                                       |                 |
 | `group_dn`        | String        |                          | LDAP distinguished name (DN) of LDAP group. If you want to match all (or no LDAP groups) then you can use wildcard ("*") |
 | `org_role`        | String        | `Viewer`                 | Assign users of group_dn the organization role | Admin Editor Viewer
 | `grafana_admin`   | true, false   | `false`                  | When true makes user of group_dn Grafana server admin. A Grafana server admin has admin access over all organizations and users. Available in Grafana v5.3 and above|
@@ -24,7 +25,8 @@ Introduced: v4.0.0
 ## Examples
 
 ```ruby
-grafana_config_ldap_group_mappings 'cn=admins,dc=grafana,dc=org' do
+grafana_config_ldap_group_mappings 'grafana' do
+  group_dn 'cn=admins,dc=grafana,dc=org'
   org_role      'Admin'
   grafana_admin true
   org_id        1
@@ -32,7 +34,8 @@ end
 ```
 
 ```ruby
-grafana_config_ldap_group_mappings 'cn=readers,dc=grafana,dc=org' do
+grafana_config_ldap_group_mappings 'grafana' do
+  group_dn 'cn=readers,dc=grafana,dc=org'
   org_role      'Viewer'
 end
 ```


### PR DESCRIPTION
# Description

Documenation fix for `grafana_config_ldap_group_mappings`

Name property is `instance_name` instead of `group_dn`.
Action name is `:install`.

## Issues Resolved

None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.

This is a documentation-only patch.