### PR TITLE
Enable unified_mode for all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ This file is used to list changes made in each version of grafana.
 
 ## 9.6.2 - *2021-06-01*
 
+- Standardise cookbook files
+
 ## 9.6.1 - *2021-05-11*
+
+- Standardise cookbook files
 
 ## 9.6.0 - *2021-02-17*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of grafana.
 ## Unreleased
 
 - Enable `unified_mode` for all resources
+- Deprecated `grafana_dashboard`, `grafana_dashboard_template`, and `grafana_dashboard_backup` resources
+  - These use the old dashboard name API which was removed in the latest 8.0 release of Grafana
 
 ## 9.6.2 - *2021-06-01*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of grafana.
 
 ## Unreleased
 
+- Enable `unified_mode` for all resources
+
 ## 9.6.2 - *2021-06-01*
 
 ## 9.6.1 - *2021-05-11*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,17 @@ This file is used to list changes made in each version of grafana.
 ## Unreleased
 
 - Enable `unified_mode` for all resources
-- Deprecated `grafana_dashboard`, `grafana_dashboard_template`, and `grafana_dashboard_backup` resources
+
+### Deprecations
+
+All Grafana API resources will be removed in a future version of this cookbook. Other tools e.g. Terraform are better
+suited for interacting with the API.
+
+- `grafana_dashboard`, `grafana_dashboard_template`, `grafana_dashboard_backup`
   - These use the old dashboard name API which was removed in the latest 8.0 release of Grafana
+- `grafana_datasource`, `grafana_datasource_backup`
+- `grafana_organization`
+- `grafana_user`
 
 ## 9.6.2 - *2021-06-01*
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -4,13 +4,13 @@ driver:
   # because Docker and SystemD
   privileged: true
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
-  env: [CHEF_LICENSE=accept-no-persist]
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
+  chef_license: accept-no-persist
 
 platforms:
   - name: debian-9

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,17 +1,16 @@
 ---
 driver:
   name: dokken
+  # because Docker and SystemD
   privileged: true
-  env: [CHEF_LICENSE=accept]
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  env: [CHEF_LICENSE=accept-no-persist]
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
-  product_name: chef
-  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
-  install_strategy: once
 
 platforms:
   - name: debian-9

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -38,6 +38,7 @@ suites:
     run_list:
       - recipe[test::proxy]
     provisioner:
+      # grafana_user update not idempotent
       enforce_idempotency: false
       multiple_converge: 1
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,6 +5,7 @@ driver:
 provisioner:
   name: chef_zero
   product_name: chef
+  chef_license: accept-no-persist
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   install_strategy: once
   enforce_idempotency: true
@@ -48,6 +49,7 @@ suites:
       - recipe[test::plugins]
       - recipe[test::sleep]
     provisioner:
+      # grafana_plugin with url not idempotent
       enforce_idempotency: false
       multiple_converge: 1
 
@@ -59,6 +61,7 @@ suites:
     run_list:
       - recipe[test::configure]
     provisioner:
+      # grafana_user update not idempotent
       enforce_idempotency: false
       multiple_converge: 1
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,9 +7,10 @@ provisioner:
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   install_strategy: once
+  enforce_idempotency: true
+  multiple_converge: 2
+  deprecations_as_errors: true
 
-client_rb:
-  treat_deprecation_warnings_as_errors: true
 verifier:
   name: inspec
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_name: cinc
+  product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   install_strategy: once
   enforce_idempotency: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_name: chef
+  product_name: cinc
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   install_strategy: once
   enforce_idempotency: true
@@ -27,18 +27,28 @@ suites:
   - name: default
     run_list:
       - recipe[test::install]
+      - recipe[test::sleep]
 
   - name: ldap
     run_list:
       - recipe[test::ldap]
+      - recipe[test::sleep]
 
   - name: proxy
     run_list:
       - recipe[test::proxy]
+    provisioner:
+      enforce_idempotency: false
+      multiple_converge: 1
+
 
   - name: plugins
     run_list:
       - recipe[test::plugins]
+      - recipe[test::sleep]
+    provisioner:
+      enforce_idempotency: false
+      multiple_converge: 1
 
   - name: basic
     run_list:
@@ -47,10 +57,14 @@ suites:
   - name: configure
     run_list:
       - recipe[test::configure]
+    provisioner:
+      enforce_idempotency: false
+      multiple_converge: 1
 
   - name: azuread
     run_list:
       - recipe[test::azuread]
+      - recipe[test::sleep]
 
   - name: config_plugins
     run_list:

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -20,6 +20,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,       String,                   name_property: true
 property  :env_directory,       String,                   default: '/etc/default'
 property  :owner,               String,                   default: 'grafana'

--- a/resources/config_alerting.rb
+++ b/resources/config_alerting.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,           String,         name_property: true
 property  :enabled,                 [true, false],  default: true
 property  :execute_alerts,          [true, false],  default: true

--- a/resources/config_auth.rb
+++ b/resources/config_auth.rb
@@ -17,6 +17,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,                                  String,         name_property: true
 property  :login_cookie_name,                              String,         required: false
 property  :disable_login_form,                             [true, false],  default: false

--- a/resources/config_auth_azuread.rb
+++ b/resources/config_auth_azuread.rb
@@ -17,6 +17,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,                          String,         name_property: true
 property  :auth_name,                              String,         default: 'AzureAD'
 property  :enabled,                                [true, false],  default: false

--- a/resources/config_dashboards.rb
+++ b/resources/config_dashboards.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,     String,   name_property: true
 property  :versions_to_keep,  Integer,  default: 20
 property  :min_refresh_interval, String, default: '5s'

--- a/resources/config_database.rb
+++ b/resources/config_database.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,     String,                   name_property: true
 property  :type,              Symbol,                   default: :sqlite3, equal_to: %i( mysql postgres sqlite3 )
 property  :host,              String,                   default: '127.0.0.1:3306'

--- a/resources/config_dataproxy.rb
+++ b/resources/config_dataproxy.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,   String,         name_property: true
 property  :logging,         [true, false],  default: false
 

--- a/resources/config_emails.rb
+++ b/resources/config_emails.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,             String,         name_property: true
 property  :welcome_email_on_sign_up,  [true, false],  default: false
 property  :templates_pattern,         String,         default: 'emails/*.html'

--- a/resources/config_enterprise.rb
+++ b/resources/config_enterprise.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,   String, name_property: true
 property  :license_path,    String, default: ''
 

--- a/resources/config_explore.rb
+++ b/resources/config_explore.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,   String,         name_property: true
 property  :enabled,         [true, false],  default: false
 

--- a/resources/config_external_image_storage_s3.rb
+++ b/resources/config_external_image_storage_s3.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,           String,         name_property: true
 property  :storage_provider,        String,         default: 's3'
 property  :region,                  String,         required: true

--- a/resources/config_ldap.rb
+++ b/resources/config_ldap.rb
@@ -19,6 +19,8 @@
 # Configures the installed grafana instance's ldap settings
 # See https://raw.githubusercontent.com/grafana/grafana/master/conf/ldap.toml
 
+unified_mode true
+
 property  :instance_name,                 String, name_property: true
 property  :log_filters,                   String
 property  :servers_attributes_name,       String, default: 'givenName'

--- a/resources/config_ldap_group_mappings.rb
+++ b/resources/config_ldap_group_mappings.rb
@@ -20,6 +20,8 @@
 # See https://raw.githubusercontent.com/grafana/grafana/master/conf/ldap.toml
 # Expects config_ldap to have been called before this
 
+unified_mode true
+
 property  :instance_name,                 String,                   name_property: true
 property  :group_dn,                      String,                   required: true
 property  :org_role,                      String,                   default: 'Viewer'

--- a/resources/config_ldap_servers.rb
+++ b/resources/config_ldap_servers.rb
@@ -20,6 +20,8 @@
 # See https://raw.githubusercontent.com/grafana/grafana/master/conf/ldap.toml
 # Expects config_ldap to have been called before this
 
+unified_mode true
+
 property  :instance_name,                       String,                   name_property: true
 property  :host,                                String,                   required: true
 property  :port,                                Integer,                  default: 389

--- a/resources/config_log.rb
+++ b/resources/config_log.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,       String,         name_property: true
 property  :mode,                String,         default: 'console file'
 property  :level,               String,         default: 'info'

--- a/resources/config_metrics.rb
+++ b/resources/config_metrics.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,       String,         name_property: true
 property  :enabled,             [true, false],  default: true
 property  :interval_seconds,    Integer,        default: 10

--- a/resources/config_panels.rb
+++ b/resources/config_panels.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,   String,         name_property: true
 property  :enable_alpha,    [true, false],  default: false
 

--- a/resources/config_paths.rb
+++ b/resources/config_paths.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,       String, name_property: true
 property  :data,                String, default: '/var/lib/grafana'
 property  :temp_data_lifetime,  String, default: '24h'

--- a/resources/config_plugins.rb
+++ b/resources/config_plugins.rb
@@ -18,6 +18,8 @@
 #
 # Configures the [plugins] section of the grafana config file
 
+unified_mode true
+
 property  :instance_name, String, name_property: true
 property  :allow_loading_unsigned_plugins, Array, default: []
 

--- a/resources/config_quota.rb
+++ b/resources/config_quota.rb
@@ -17,6 +17,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,     String,         name_property: true
 property  :enabled,           [true, false],  default: false
 property  :org_user,          Integer,        default: 10

--- a/resources/config_remote_cache.rb
+++ b/resources/config_remote_cache.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,       String,         name_property: true
 property  :remote_cache_type,   Symbol,         default: :database, equal_to: %i( redis memcached database )
 property  :remote_cache_config, String,         default: ''

--- a/resources/config_rendering.rb
+++ b/resources/config_rendering.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name, String, name_property: true
 property  :server_url,    String, default: 'http://localhost:8081/render'
 property  :callback_url,  String, default: 'http://localhost:3000/'

--- a/resources/config_security.rb
+++ b/resources/config_security.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,                         String,         name_property: true
 property  :admin_user,                            String,         default: 'admin'
 property  :admin_password,                        String,         default: 'admin'

--- a/resources/config_server.rb
+++ b/resources/config_server.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,        String,         name_property: true
 property  :protocol,             Symbol,         default: :http, equal_to: %i( http https socket )
 property  :http_addr,            String,         default: ''

--- a/resources/config_session.rb
+++ b/resources/config_session.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,     String,         name_property: true
 # using session_provider due to: ArgumentError: Property `provider` of resource `` overwrites an existing method.
 property  :session_provider,  Symbol,         default: :file, equal_to: %i( memory file redis mysql postgres memcache )

--- a/resources/config_smtp.rb
+++ b/resources/config_smtp.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,   String,         name_property: true
 property  :enabled,         [true, false],  default: false
 property  :host,            String,         default: 'localhost:25'

--- a/resources/config_snapshots.rb
+++ b/resources/config_snapshots.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,           String,         name_property: true
 property  :external_enabled,        [true, false],  default: true
 property  :external_snapshot_url,   String,         default: 'https://snapshots-origin.raintank.io'

--- a/resources/config_users.rb
+++ b/resources/config_users.rb
@@ -18,6 +18,8 @@
 #
 # Configures the installed grafana instance
 
+unified_mode true
+
 property  :instance_name,             String,         name_property: true
 property  :allow_sign_up,             [true, false],  default: false
 property  :allow_org_create,          [true, false],  default: false

--- a/resources/config_writer.rb
+++ b/resources/config_writer.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property  :instance_name,       String,                   name_property: true
 property  :is_sensitive,        [true, false],            default: true
 property  :conf_directory,      String,                   default: '/etc/grafana'

--- a/resources/dashboard.rb
+++ b/resources/dashboard.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+unified_mode true
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/dashboard.rb
+++ b/resources/dashboard.rb
@@ -21,6 +21,9 @@
 
 unified_mode true
 
+deprecated 'The `grafana_dashboard` resources will be removed in the next major version of the grafana cookbook. ' \
+  'Grafana 8.0 removed support for the dashboard API these use. Use e.g. Terraform to manage dashboards instead.'
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/dashboard.rb
+++ b/resources/dashboard.rb
@@ -22,7 +22,7 @@
 unified_mode true
 
 deprecated 'The `grafana_dashboard` resources will be removed in the next major version of the grafana cookbook. ' \
-  'Grafana 8.0 removed support for the dashboard API these use. Use e.g. Terraform to manage dashboards instead.'
+  'Grafana 8.0 removed support for the dashboard API these use. Use another tool such as Terraform to manage dashboards instead.'
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000

--- a/resources/dashboard_template.rb
+++ b/resources/dashboard_template.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
 property :url_path_prefix,    String

--- a/resources/dashboard_template.rb
+++ b/resources/dashboard_template.rb
@@ -1,7 +1,7 @@
 unified_mode true
 
 deprecated 'The `grafana_dashboard` resources will be removed in the next major version of the grafana cookbook. ' \
-  'Grafana 8.0 removed support for the dashboard API these use. Use e.g. Terraform to manage dashboards instead.'
+  'Grafana 8.0 removed support for the dashboard API these use. Use another tool such as Terraform to manage dashboards instead.'
 
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000

--- a/resources/dashboard_template.rb
+++ b/resources/dashboard_template.rb
@@ -1,5 +1,8 @@
 unified_mode true
 
+deprecated 'The `grafana_dashboard` resources will be removed in the next major version of the grafana cookbook. ' \
+  'Grafana 8.0 removed support for the dashboard API these use. Use e.g. Terraform to manage dashboards instead.'
+
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
 property :url_path_prefix,    String

--- a/resources/dashboards_backup.rb
+++ b/resources/dashboards_backup.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
 property :url_path_prefix,    String

--- a/resources/dashboards_backup.rb
+++ b/resources/dashboards_backup.rb
@@ -1,7 +1,7 @@
 unified_mode true
 
 deprecated 'The `grafana_dashboard` resources will be removed in the next major version of the grafana cookbook. ' \
-  'Grafana 8.0 removed support for the dashboard API these use. Use e.g. Terraform to manage dashboards instead.'
+  'Grafana 8.0 removed support for the dashboard API these use. Use another tool such as Terraform to manage dashboards instead.'
 
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000

--- a/resources/dashboards_backup.rb
+++ b/resources/dashboards_backup.rb
@@ -1,5 +1,8 @@
 unified_mode true
 
+deprecated 'The `grafana_dashboard` resources will be removed in the next major version of the grafana cookbook. ' \
+  'Grafana 8.0 removed support for the dashboard API these use. Use e.g. Terraform to manage dashboards instead.'
+
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
 property :url_path_prefix,    String

--- a/resources/datasource.rb
+++ b/resources/datasource.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+unified_mode true
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/datasource.rb
+++ b/resources/datasource.rb
@@ -22,7 +22,7 @@
 unified_mode true
 
 deprecated 'The `grafana_datasource` resources will be removed in the next major version of the grafana cookbook. ' \
-  'Use e.g. Terraform to interact with the Grafana API instead.'
+  'Use another tool such as Terraform to interact with the Grafana API instead.'
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000

--- a/resources/datasource.rb
+++ b/resources/datasource.rb
@@ -21,6 +21,9 @@
 
 unified_mode true
 
+deprecated 'The `grafana_datasource` resources will be removed in the next major version of the grafana cookbook. ' \
+  'Use e.g. Terraform to interact with the Grafana API instead.'
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/datasources_backup.rb
+++ b/resources/datasources_backup.rb
@@ -2,7 +2,7 @@
 unified_mode true
 
 deprecated 'The `grafana_datasource` resources will be removed in the next major version of the grafana cookbook. ' \
-  'Use e.g. Terraform to interact with the Grafana API instead.'
+  'Use another tool such as Terraform to interact with the Grafana API instead.'
 
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000

--- a/resources/datasources_backup.rb
+++ b/resources/datasources_backup.rb
@@ -1,3 +1,6 @@
+
+unified_mode true
+
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
 property :url_path_prefix,    String

--- a/resources/datasources_backup.rb
+++ b/resources/datasources_backup.rb
@@ -1,6 +1,9 @@
 
 unified_mode true
 
+deprecated 'The `grafana_datasource` resources will be removed in the next major version of the grafana cookbook. ' \
+  'Use e.g. Terraform to interact with the Grafana API instead.'
+
 property :host,               String,   default: 'localhost'
 property :port,               Integer,  default: 3000
 property :url_path_prefix,    String

--- a/resources/folder.rb
+++ b/resources/folder.rb
@@ -1,4 +1,5 @@
-# To learn more about Custom Resources, see https://docs.chef.io/custom_resources.html
+unified_mode true
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/folder.rb
+++ b/resources/folder.rb
@@ -1,5 +1,8 @@
 unified_mode true
 
+deprecated 'The `grafana_folder` resource will be removed in the next major version of the grafana cookbook. ' \
+  'Use e.g. Terraform to interact with the Grafana API instead.'
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/folder.rb
+++ b/resources/folder.rb
@@ -1,7 +1,7 @@
 unified_mode true
 
 deprecated 'The `grafana_folder` resource will be removed in the next major version of the grafana cookbook. ' \
-  'Use e.g. Terraform to interact with the Grafana API instead.'
+  'Use another tool such as Terraform to interact with the Grafana API instead.'
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+unified_mode true
+
 property :version,          String, required: false
 property :repo,             String, default:  'https://packages.grafana.com/oss'
 property :key,              String, default:  'https://packages.grafana.com/gpg.key'

--- a/resources/organization.rb
+++ b/resources/organization.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+unified_mode true
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/organization.rb
+++ b/resources/organization.rb
@@ -20,7 +20,7 @@
 #
 
 deprecated 'The `grafana_organization` resource will be removed in the next major version of the grafana cookbook. ' \
-  'Use e.g. Terraform to interact with the Grafana API instead.'
+  'Use another tool such as Terraform to interact with the Grafana API instead.'
 
 unified_mode true
 

--- a/resources/organization.rb
+++ b/resources/organization.rb
@@ -19,6 +19,9 @@
 # limitations under the License.
 #
 
+deprecated 'The `grafana_organization` resource will be removed in the next major version of the grafana cookbook. ' \
+  'Use e.g. Terraform to interact with the Grafana API instead.'
+
 unified_mode true
 
 property :host,           String,   default: 'localhost'

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -18,6 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+unified_mode true
+
 property :grafana_cli_bin, String, default: '/usr/sbin/grafana-cli'
 property :plugin_url, String
 

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+unified_mode true
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -21,6 +21,9 @@
 
 unified_mode true
 
+deprecated 'The `grafana_user` resource will be removed in the next major version of the grafana cookbook. ' \
+  'Use e.g. Terraform to interact with the Grafana API instead.'
+
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000
 property :url_path_prefix, String

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -22,7 +22,7 @@
 unified_mode true
 
 deprecated 'The `grafana_user` resource will be removed in the next major version of the grafana cookbook. ' \
-  'Use e.g. Terraform to interact with the Grafana API instead.'
+  'Use another tool such as Terraform to interact with the Grafana API instead.'
 
 property :host,           String,   default: 'localhost'
 property :port,           Integer,  default: 3000

--- a/test/fixtures/cookbooks/test/recipes/azuread.rb
+++ b/test/fixtures/cookbooks/test/recipes/azuread.rb
@@ -21,8 +21,3 @@ grafana_config_writer 'Grafana' do
   # In test we turn of sensitive so we can get better logs
   sensitive false
 end
-
-# Tests are failing as the server has not fully become available when tests run
-chef_sleep 'Sleep so inspec tests pass' do
-  seconds 25
-end

--- a/test/fixtures/cookbooks/test/recipes/configure.rb
+++ b/test/fixtures/cookbooks/test/recipes/configure.rb
@@ -21,6 +21,8 @@ end
 
 grafana_config_writer 'Grafana'
 
+include_recipe 'test::sleep'
+
 # Needed for some inspec tests
 package 'curl'
 

--- a/test/fixtures/cookbooks/test/recipes/configure.rb
+++ b/test/fixtures/cookbooks/test/recipes/configure.rb
@@ -1,7 +1,9 @@
 
 auth_header = 'X-WEBAUTH-USER'
 
-grafana_install 'grafana'
+grafana_install 'grafana' do
+  version '7.5.0' # last version to have old dashboard api
+end
 
 grafana_config 'Grafana'
 

--- a/test/fixtures/cookbooks/test/recipes/install.rb
+++ b/test/fixtures/cookbooks/test/recipes/install.rb
@@ -33,8 +33,3 @@ grafana_config_writer 'Grafana' do
   # In test we turn of sensitive so we can get better logs
   sensitive false
 end
-
-# Tests are failing as the server has not fully become available when tests run
-chef_sleep 'Sleep so inspec tests pass' do
-  seconds 25
-end

--- a/test/fixtures/cookbooks/test/recipes/ldap.rb
+++ b/test/fixtures/cookbooks/test/recipes/ldap.rb
@@ -38,8 +38,3 @@ grafana_config_writer 'Grafana' do
   # In test we turn of sensitive so we can get better logs
   sensitive false
 end
-
-# Tests are failing as the server has not fully become available when tests run
-chef_sleep 'Sleep so inspec tests pass' do
-  seconds 25
-end

--- a/test/fixtures/cookbooks/test/recipes/plugins.rb
+++ b/test/fixtures/cookbooks/test/recipes/plugins.rb
@@ -15,8 +15,3 @@ grafana_plugin 'yesoreyeram-boomtable-panel' do
   plugin_url 'https://raw.githubusercontent.com/sous-chefs/grafana/master/test/fixtures/cookbooks/test/files/plugin-test.zip'
   action :update
 end
-
-# Tests are failing as the server has not fully become available when tests run
-chef_sleep 'Sleep so inspec tests pass' do
-  seconds 25
-end

--- a/test/fixtures/cookbooks/test/recipes/sleep.rb
+++ b/test/fixtures/cookbooks/test/recipes/sleep.rb
@@ -1,0 +1,6 @@
+# Tests are failing as the server has not fully become available when tests run
+chef_sleep 'Sleep so inspec tests pass' do
+  seconds 25
+  not_if { ::File.exist? '/root/.slept' }
+end
+file '/root/.slept'

--- a/test/integration/azuread/azuread.rb
+++ b/test/integration/azuread/azuread.rb
@@ -34,7 +34,7 @@ describe json(content: http('http://localhost:3000/api/admin/settings',
   its(['auth.azuread', 'name']) { should eq 'Test Azure AD' }
   its(['auth.azuread', 'allow_sign_up']) { should eq 'true' }
   its(['auth.azuread', 'client_id']) { should eq 'test_id' }
-  its(['auth.azuread', 'client_secret']) { should eq '************' }
+  its(['auth.azuread', 'client_secret']) { should eq '*********' }
   its(['auth.azuread', 'auth_url']) { should eq 'https://login.microsoftonline.com/12345/oauth2/authorize' }
   its(['auth.azuread', 'token_url']) { should eq 'https://login.microsoftonline.com/12345/oauth2/token' }
   its(['auth.azuread', 'scopes']) { should eq 'openid email name groups' }


### PR DESCRIPTION
# Description

Enables `unified_mode` on all resources to prepare for Chef 17.

Also fixes idempotency in the test recipe and enables idempotency checks.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing. -- n/a
- [ ] New functionality has been documented in the README if applicable. -- n/a
