### PR TITLE
Remove redundant config_writer notice from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of grafana.
 
 ## Unreleased
 
+- Remove redundant conflicting config_writer notice from README
+
 ## 10.0.0 - *2021-10-20*
 
 - Automatic config Hash path creation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ## Requirements
 
-- Chef Client 13+
+- Chef Infra 16+
 
 ### Platforms
 
@@ -27,15 +27,6 @@ This cookbook officially supports and is tested against the following platforms:
 - CentOS/Redhat >= 6
 
 PRs are welcome to add support for additional platforms.
-
-## Configuration Resource Features
-
-We supply many different configuration resources, these all rely on the base config resource being called
-
-For any LDAP the base config resource is: `grafana_config_ldap`
-For any core configuration resources, the base config resource is: `grafana_config`
-
-**NOTE**: Inorder to write the above configuration resources to the disk use [grafana_config_writer](https://github.com/sous-chefs/grafana/tree/main/documentation/grafana_config_writer.md) at the end.
 
 ## Resources
 


### PR DESCRIPTION
# Description

- Remove redundant config_writer notice from README

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
