### PR TITLE
Fix resource_config_path for generic_oauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of grafana.
 ## Unreleased
 
 - Remove delivery folder
+- Fix resource_config_path for generic_oauth
 
 ## 10.0.1 - *2021-10-21*
 

--- a/resources/config_auth_generic_oauth.rb
+++ b/resources/config_auth_generic_oauth.rb
@@ -67,3 +67,7 @@ action :create do
     accumulator_config(:set, rp.to_s.delete_prefix('oauth_'), new_resource.send(rp))
   end
 end
+
+def resource_config_path_override
+  %w(auth.generic_oauth)
+end


### PR DESCRIPTION
# Description

The code in `resource_default_config_path` replaces all underscores with
dots, while Grafana expects expects to find [`auth.generic_oauth`](https://grafana.com/docs/grafana/latest/auth/generic-oauth/).

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
