### PR TITLE
Remove deep_sort on LDAP group_mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of grafana.
 
 ## Unreleased
 
+- Remove deep_sort on ldap group_mappings (#417)
+
 ## 10.0.6 - *2022-10-12*
 
 - Correct `config_ldap_group_mapping` documentation file name

--- a/libraries/toml.rb
+++ b/libraries/toml.rb
@@ -40,10 +40,13 @@ module Grafana
       # @param content [Hash] The file contents as a Hash
       # @return [String] Formatted toml output
       #
-      def tomlfile_string(content)
+      def tomlfile_string(content, deep_sort: false)
         raise ArgumentError, "Expected Hash got #{content.class}" unless content.is_a?(Hash)
 
-        ::TomlRB.dump(content.deep_sort)
+        file_content = content
+        file_content.deep_sort! if deep_sort
+
+        ::TomlRB.dump(file_content)
       end
     end
   end

--- a/resources/config_ldap_attributes.rb
+++ b/resources/config_ldap_attributes.rb
@@ -77,7 +77,7 @@ action :create do
       next if nil_or_empty?(new_resource.send(rp))
 
       [rp.to_s.delete_prefix('attribute_'), new_resource.send(rp)]
-    end.compact.to_h
+    end.compact.sort.to_h
 
     ldap_server_config(new_resource.host)['attributes'] = attributes
   end

--- a/resources/config_ldap_group_mapping.rb
+++ b/resources/config_ldap_group_mapping.rb
@@ -93,13 +93,12 @@ action :create do
       next if nil_or_empty?(new_resource.send(rp))
 
       [rp.to_s, new_resource.send(rp)]
-    end.compact.to_h
+    end.compact.sort.to_h
 
     remove_group_mapping if group_mapping_exist?
 
     ldap_server_config(new_resource.host)['group_mappings'] ||= []
     ldap_server_config(new_resource.host)['group_mappings'].push(mapping)
-    ldap_server_config(new_resource.host)['group_mappings'].sort_by! { |gm| gm['group_dn'] }
   end
 end
 

--- a/resources/config_ldap_server.rb
+++ b/resources/config_ldap_server.rb
@@ -80,7 +80,7 @@ action :create do
       next if nil_or_empty?(new_resource.send(rp))
 
       [rp.to_s, new_resource.send(rp)]
-    end.compact.to_h
+    end.compact.sort.to_h
 
     if ldap_server_config(new_resource.host)
       ldap_server_config(new_resource.host).merge!(ldap_server)

--- a/test/fixtures/cookbooks/test/recipes/ldap.rb
+++ b/test/fixtures/cookbooks/test/recipes/ldap.rb
@@ -55,6 +55,35 @@ grafana_config_ldap_group_mapping 'cn=admins,dc=grafana,dc=org' do
   org_id 1
 end
 
+grafana_config_ldap_group_mapping 'editors' do
+  sensitive false
+
+  host '127.0.0.1'
+  group_dn 'cn=editors,dc=grafana,dc=org'
+  org_role 'Viewer'
+  grafana_admin false
+  org_id 1
+end
+
+grafana_config_ldap_group_mapping 'readers' do
+  sensitive false
+
+  host '127.0.0.1'
+  group_dn 'cn=readers,dc=grafana,dc=org'
+  org_role 'Viewer'
+  grafana_admin false
+  org_id 1
+end
+
+grafana_config_ldap_group_mapping 'everyone' do
+  sensitive false
+
+  host '127.0.0.1'
+  group_dn '*'
+  org_role 'Viewer'
+  grafana_admin false
+  org_id 1
+end
 grafana_config_ldap_group_mapping 'readers' do
   sensitive false
 
@@ -79,15 +108,6 @@ grafana_config_ldap_group_mapping 'cn=users,ou=groups,dc=grafana,dc=org' do
 
   host '127.0.0.1'
   org_role 'Editor'
-
-  action :delete
-end
-
-grafana_config_ldap_group_mapping '*' do
-  sensitive false
-
-  host '127.0.0.1'
-  org_role 'Viewer'
 
   action :delete
 end

--- a/test/integration/ldap/ldap_spec.rb
+++ b/test/integration/ldap/ldap_spec.rb
@@ -39,21 +39,26 @@ describe toml('/etc/grafana/ldap.toml') do
   its(['servers', 0, 'attributes', 'member_of']) { should eq 'memberOf' }
   its(['servers', 0, 'attributes', 'email']) { should eq 'email' }
 
-  its(['servers', 0, 'group_mappings', 1, 'group_dn']) { should eq 'cn=admins,dc=grafana,dc=org' }
-  its(['servers', 0, 'group_mappings', 1, 'org_role']) { should eq 'Admin' }
-  its(['servers', 0, 'group_mappings', 1, 'org_id']) { should eq 1 }
-  its(['servers', 0, 'group_mappings', 1, 'grafana_admin']) { should eq true }
-
-  its(['servers', 0, 'group_mappings', 0, 'group_dn']) { should eq 'cn=readers,dc=grafana,dc=org' }
-  its(['servers', 0, 'group_mappings', 0, 'org_role']) { should eq 'Viewer' }
+  its(['servers', 0, 'group_mappings', 0, 'group_dn']) { should eq 'cn=admins,dc=grafana,dc=org' }
+  its(['servers', 0, 'group_mappings', 0, 'org_role']) { should eq 'Admin' }
   its(['servers', 0, 'group_mappings', 0, 'org_id']) { should eq 1 }
-  its(['servers', 0, 'group_mappings', 0, 'grafana_admin']) { should eq false }
+  its(['servers', 0, 'group_mappings', 0, 'grafana_admin']) { should eq true }
+
+  its(['servers', 0, 'group_mappings', 2, 'group_dn']) { should eq '*' }
+  its(['servers', 0, 'group_mappings', 2, 'org_role']) { should eq 'Viewer' }
+  its(['servers', 0, 'group_mappings', 2, 'org_id']) { should eq 1 }
+  its(['servers', 0, 'group_mappings', 2, 'grafana_admin']) { should eq false }
+
+  its(['servers', 0, 'group_mappings', 3, 'group_dn']) { should eq 'cn=readers,dc=grafana,dc=org' }
+  its(['servers', 0, 'group_mappings', 3, 'org_role']) { should eq 'Viewer' }
+  its(['servers', 0, 'group_mappings', 3, 'org_id']) { should eq 1 }
+  its(['servers', 0, 'group_mappings', 3, 'grafana_admin']) { should eq false }
 end
 
 describe file('/etc/grafana/ldap.toml') do
   its('content') { should_not match /cn=admins,ou=groups,dc=grafana,dc=org/ }
   its('content') { should_not match /cn=users,ou=groups,dc=grafana,dc=org/ }
-  its('content') { should_not match /group_dn = "\*"/ }
+  its('content') { should match /group_dn = "\*"/ }
 end
 
 describe service('grafana-server') do


### PR DESCRIPTION
# Description

Remove deep_sort on LDAP group_mappings

Closes #417

## Issues Resolved

- #417 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
