### PR TITLE
config: add enabled property on config_unified_alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of grafana.
 
 ## Unreleased
 
+* Add `enabled` property to `config_unified_alerting` resource; this permits opting out of unified alerting that was [introduced](https://grafana.com/docs/grafana/v9.0/alerting/migrating-alerts/opt-out/) in v9.0.
+
 ## 10.1.0 - *2022-10-13*
 
 - Remove deep_sort on ldap group_mappings (#417)

--- a/resources/config_unified_alerting.rb
+++ b/resources/config_unified_alerting.rb
@@ -21,3 +21,9 @@ unified_mode true
 use 'partial/_config_file'
 
 property :admin_config_poll_interval_seconds, Integer
+# It is enabled by default on Grafana >=9.0: https://grafana.com/docs/grafana/v9.0/alerting/migrating-alerts/opt-out/.
+property :enabled, [true, false], default: true
+
+def resource_config_path_override
+  %w(unified_alerting)
+end

--- a/test/fixtures/cookbooks/test/recipes/configure.rb
+++ b/test/fixtures/cookbooks/test/recipes/configure.rb
@@ -19,6 +19,10 @@ grafana_config_dashboards 'Grafana' do
   min_refresh_interval '3s'
 end
 
+grafana_config_unified_alerting 'Grafana' do
+  enabled false
+end
+
 grafana_service 'grafana' do
   action %i(enable start)
   subscribes :restart, 'template[/etc/grafana/grafana.ini]', :delayed


### PR DESCRIPTION
# Description

Add enabled property on the config_unified_alerting resource that permits disabling/enabling unified alerting that was introduced in v9.0: https://grafana.com/docs/grafana/v9.0/alerting/migrating-alerts/opt-out/.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
