### PR TITLE
Add resource_config_path_override to config_external_image_storage resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of grafana.
 
 ## Unreleased
 
+- Fix `config_external_image_storage` config path override ([Grafana Docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_image_storage))
+
 ## 10.5.0 - *2023-07-21*
 
 - Add `config_unified_alerting_screenshots` resource ([Grafana Docs](([Grafana Docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/#enable-email-lookup))))

--- a/resources/config_external_image_storage.rb
+++ b/resources/config_external_image_storage.rb
@@ -29,3 +29,7 @@ def resource_config_properties_translate
     storage_provider: 'provider',
   }.freeze
 end
+
+def resource_config_path_override
+  %w(external_image_storage)
+end


### PR DESCRIPTION
# Description
Currently, the resource path is not being overwritten and Grafana does not recognize it:
```
[root@node1-centos-7 ~]# grep external /etc/grafana/grafana.ini 
[external.image.storage]
```
![image](https://github.com/sous-chefs/grafana/assets/48908420/1c93f3c7-5d48-443f-a17a-4326c816447c)
Which leads to the image not being uploaded to external storage:
`logger=ngalert.image rule_uid=b7e8a7d4-e206-4979-a7fa-6bba86714916 org_id=1 dashboard=isFoa0z7k panel=7 t=2023-07-24T12:30:23.190600749Z level=debug msg="Uploaded image" url=`
The url is empty. 

After path override:
```
[root@node1-centos-7]# grep external /etc/grafana/grafana.ini 
[external_image_storage]
```
![image](https://github.com/sous-chefs/grafana/assets/48908420/30501a94-f38c-47ac-a026-0e4ddf6dd496)

And the image is uploaded successfully:
`logger=ngalert.image rule_uid=aa9560e3-c8c8-4da9-abe8-a51daa8a2fc2 org_id=1 dashboard=ef55bd0b-4527-4f00-8b28-a10be4b38deb panel=1 t=2023-07-24T12:21:07.807468257Z level=debug msg="Uploaded image" url=https://s3-xxxxxxxxxxx/grafana-s3-images/images/AX5etM1bxx0xN83qV5nD.png`
## Issues Resolved

N/A

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
