### PR TITLE
fix: added org_id to ldap group mapping functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of grafana.
 
 ## Unreleased
+Added org_ids to ldap_mapping functions
 
 ## 10.7.4 - *2024-07-15*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # CHANGELOG for grafana
+
 This file is used to list changes made in each version of grafana.
 
 ## Unreleased
 
-Added org_ids to ldap_mapping functions
+- Added org_ids to ldap_mapping functions
 
 ## 10.7.4 - *2024-07-15*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG for grafana
-
 This file is used to list changes made in each version of grafana.
 
 ## Unreleased
+
 Added org_ids to ldap_mapping functions
 
 ## 10.7.4 - *2024-07-15*

--- a/resources/config_ldap_group_mapping.rb
+++ b/resources/config_ldap_group_mapping.rb
@@ -71,7 +71,7 @@ action_class do
 
     return unless group_mappings
 
-    group_mappings.any? { |gm| gm['group_dn'].eql?(new_resource.group_dn) && gm['org_role'].eql?(new_resource.org_role) }
+    group_mappings.any? { |gm| gm['group_dn'].eql?(new_resource.group_dn) && gm['org_role'].eql?(new_resource.org_role) && gm['org_role'].eql?(new_resource.org_role)}
   end
 
   def remove_group_mapping
@@ -81,7 +81,7 @@ action_class do
 
     return unless group_mappings
 
-    group_mappings.delete_if { |gm| gm['group_dn'].eql?(new_resource.group_dn) && gm['org_role'].eql?(new_resource.org_role) }
+    group_mappings.delete_if { |gm| gm['group_dn'].eql?(new_resource.group_dn) && gm['org_role'].eql?(new_resource.org_role) && gm['org_id'].eql?(new_resource.org_id) }
   end
 end
 
@@ -103,5 +103,5 @@ action :create do
 end
 
 action :delete do
-  converge_by("Remove LDAP server #{new_resource.host} group mapping for #{new_resource.group_dn}") { remove_group_mapping } if group_mapping_exist?
+  converge_by("Remove LDAP server #{new_resource.host} group mapping for #{new_resource.group_dn} from OrgID #{new_resource.org_id}") { remove_group_mapping } if group_mapping_exist?
 end

--- a/resources/config_ldap_group_mapping.rb
+++ b/resources/config_ldap_group_mapping.rb
@@ -71,7 +71,7 @@ action_class do
 
     return unless group_mappings
 
-    group_mappings.any? { |gm| gm['group_dn'].eql?(new_resource.group_dn) && gm['org_role'].eql?(new_resource.org_role) && gm['org_role'].eql?(new_resource.org_role)}
+    group_mappings.any? { |gm| gm['group_dn'].eql?(new_resource.group_dn) && gm['org_role'].eql?(new_resource.org_role) && gm['org_id'].eql?(new_resource.org_id)}
   end
 
   def remove_group_mapping

--- a/resources/config_ldap_group_mapping.rb
+++ b/resources/config_ldap_group_mapping.rb
@@ -71,7 +71,7 @@ action_class do
 
     return unless group_mappings
 
-    group_mappings.any? { |gm| gm['group_dn'].eql?(new_resource.group_dn) && gm['org_role'].eql?(new_resource.org_role) && gm['org_id'].eql?(new_resource.org_id)}
+    group_mappings.any? { |gm| gm['group_dn'].eql?(new_resource.group_dn) && gm['org_role'].eql?(new_resource.org_role) && gm['org_id'].eql?(new_resource.org_id) }
   end
 
   def remove_group_mapping


### PR DESCRIPTION
... to support more than one org pr server instance

# Description

lets the resource define more than one organization pr server instance by including the org_id.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
