### PR TITLE
fix: Sorts group mappings in ldap.toml by org_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of grafana.
 
 ## Unreleased
 
+- Fix: Sorts group mappings in ldap.toml by org_role
+
 ## 10.8.0 - *2024-09-27*
 
 - Added org_ids to ldap_mapping functions

--- a/libraries/ldap_config_file.rb
+++ b/libraries/ldap_config_file.rb
@@ -77,12 +77,12 @@ module Grafana
       # @param group_dn [String] The group DN to return configuration for
       # @return [Hash] Host attribute configuration
       #
-      def load_file_ldap_config_host_group_mapping(config_file, host, group_dn)
+      def load_file_ldap_config_host_group_mapping(config_file, host, org_role)
         host_config = load_file_ldap_config_host(config_file, host)
 
         return if nil_or_empty?(host_config)
 
-        group_mapping = host_config.fetch('group_mappings', []).select { |gm| gm['group_dn'].eql?(group_dn) }.first
+        group_mapping = host_config.fetch('group_mappings', []).select { |gm| gm['org_role'].eql?(org_role) }.first
         Chef::Log.debug("load_file_ldap_config_host_group_mapping: #{config_file} host #{host} group #{group_dn} - [#{group_mapping.class}] #{group_mapping}")
 
         group_mapping

--- a/libraries/ldap_config_file.rb
+++ b/libraries/ldap_config_file.rb
@@ -77,13 +77,13 @@ module Grafana
       # @param group_dn [String] The group DN to return configuration for
       # @return [Hash] Host attribute configuration
       #
-      def load_file_ldap_config_host_group_mapping(config_file, host, org_role)
+      def load_file_ldap_config_host_group_mapping(config_file, host, org_id)
         host_config = load_file_ldap_config_host(config_file, host)
 
         return if nil_or_empty?(host_config)
 
-        group_mapping = host_config.fetch('group_mappings', []).select { |gm| gm['org_role'].eql?(org_role) }.first
-        Chef::Log.debug("load_file_ldap_config_host_group_mapping: #{config_file} host #{host} group #{group_dn} - [#{group_mapping.class}] #{group_mapping}")
+        group_mapping = host_config.fetch('group_mappings', []).select { |gm| gm['org_id'].eql?(org_id) }.first
+        Chef::Log.debug("load_file_ldap_config_host_group_mapping: #{config_file} host #{host} group #{org_id} - [#{group_mapping.class}] #{group_mapping}")
 
         group_mapping
       end

--- a/resources/config_ldap_group_mapping.rb
+++ b/resources/config_ldap_group_mapping.rb
@@ -91,24 +91,15 @@ action :create do
   converge_if_changed do
     mapping = resource_properties.map do |rp|
       next if nil_or_empty?(new_resource.send(rp))
-
       [rp.to_s, new_resource.send(rp)]
     end.compact.to_h
 
-    # Fjern eksisterende gruppemapping om den finnes
     remove_group_mapping if group_mapping_exist?
-
-    # Hent eksisterende group_mappings eller opprett en tom liste hvis ingen finnes
     ldap_server_config(new_resource.host)['group_mappings'] ||= []
-
-    # Legg til den nye gruppemappingen
     ldap_server_config(new_resource.host)['group_mappings'].push(mapping)
-
-    # Sorter group_mappings etter org_role
     ldap_server_config(new_resource.host)['group_mappings'].sort_by! { |gm| gm['org_role'] }
   end
 end
-
 
 action :delete do
   converge_by("Remove LDAP server #{new_resource.host} group mapping for #{new_resource.group_dn} from OrgID #{new_resource.org_id}") { remove_group_mapping } if group_mapping_exist?

--- a/resources/config_ldap_group_mapping.rb
+++ b/resources/config_ldap_group_mapping.rb
@@ -93,14 +93,22 @@ action :create do
       next if nil_or_empty?(new_resource.send(rp))
 
       [rp.to_s, new_resource.send(rp)]
-    end.compact.sort.to_h
+    end.compact.to_h
 
+    # Fjern eksisterende gruppemapping om den finnes
     remove_group_mapping if group_mapping_exist?
 
+    # Hent eksisterende group_mappings eller opprett en tom liste hvis ingen finnes
     ldap_server_config(new_resource.host)['group_mappings'] ||= []
+
+    # Legg til den nye gruppemappingen
     ldap_server_config(new_resource.host)['group_mappings'].push(mapping)
+
+    # Sorter group_mappings etter org_role
+    ldap_server_config(new_resource.host)['group_mappings'].sort_by! { |gm| gm['org_role'] }
   end
 end
+
 
 action :delete do
   converge_by("Remove LDAP server #{new_resource.host} group mapping for #{new_resource.group_dn} from OrgID #{new_resource.org_id}") { remove_group_mapping } if group_mapping_exist?

--- a/resources/config_ldap_group_mapping.rb
+++ b/resources/config_ldap_group_mapping.rb
@@ -39,7 +39,7 @@ property :grafana_admin, [true, false]
 property :org_id, Integer
 
 load_current_value do |new_resource|
-  current_config = load_file_ldap_config_host_group_mapping(new_resource.config_file, new_resource.host, new_resource.org_role)
+  current_config = load_file_ldap_config_host_group_mapping(new_resource.config_file, new_resource.host, new_resource.group_dn)
 
   current_value_does_not_exist! unless current_config
 
@@ -97,7 +97,7 @@ action :create do
     remove_group_mapping if group_mapping_exist?
     ldap_server_config(new_resource.host)['group_mappings'] ||= []
     ldap_server_config(new_resource.host)['group_mappings'].push(mapping)
-    ldap_server_config(new_resource.host)['group_mappings'].sort_by! { |gm| gm['org_role'] }
+    ldap_server_config(new_resource.host)['group_mappings'].sort_by! { |gm| gm['org_id'] }
   end
 end
 

--- a/resources/config_ldap_group_mapping.rb
+++ b/resources/config_ldap_group_mapping.rb
@@ -39,7 +39,7 @@ property :grafana_admin, [true, false]
 property :org_id, Integer
 
 load_current_value do |new_resource|
-  current_config = load_file_ldap_config_host_group_mapping(new_resource.config_file, new_resource.host, new_resource.group_dn)
+  current_config = load_file_ldap_config_host_group_mapping(new_resource.config_file, new_resource.host, new_resource.org_role)
 
   current_value_does_not_exist! unless current_config
 


### PR DESCRIPTION
# Description

Due to the way Grafana reads group mappings, the mappings needs to be sorted so it reads them in this order: Admin->Editor -> Viewer.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
