### PR TITLE
fix: add Grafana 13.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 This file is used to list changes made in each version of grafana.
 
-Standardise files with files in sous-chefs/repo-management
-Standardise files with files in sous-chefs/repo-management
-
 ## [10.8.4](https://github.com/sous-chefs/grafana/compare/10.8.3...v10.8.4) (2025-10-15)
 
 

--- a/documentation/grafana_config_rendering.md
+++ b/documentation/grafana_config_rendering.md
@@ -18,6 +18,7 @@ Introduced: v8.8.0
 | `server_url`                      | String  | `http://localhost:8081/render` | URL to a remote HTTP image renderer service                                                                                                                                                                                                                          |
 | `callback_url`                    | String  | `http://localhost:3000/`       | If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. <http://grafana.domain/>.                                                                        |
 | `concurrent_render_request_limit` | Integer | `http://localhost:3000/`       | Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server, which this setting can help protect against by only allowing a certain number of concurrent requests. Default is 30. |
+| `renderer_token`                  | String  |                                | Authentication token for the remote renderer service. Required in Grafana 13.0+.                                                                                                                                                                                     |
 
 ## Examples
 

--- a/documentation/grafana_plugin.md
+++ b/documentation/grafana_plugin.md
@@ -16,7 +16,7 @@ This ressource will help you to manage grafana plugins.
 | --------------------- | ----------- | ------------------------ | --------------------------------------------------------- | --------------- |
 | `name`                | String      |                          | Name of the plugin.                                       |                 |
 | `action`              | String      | `install`                | Valid actions are `install`, `update`, `remove`.          |                 |
-| `grafana_cli_bin`     | String      | `/usr/sbin/grafana-cli`  | The path to the grafana-cli binary                        |                 |
+| `grafana_cli_bin`     | String      | `/usr/sbin/grafana cli`  | The path to the grafana cli binary                        |                 |
 | `plugin_url`          | String      |                          | The url to the custom plugin location                     |                 |
 
 ## Examples
@@ -24,7 +24,7 @@ This ressource will help you to manage grafana plugins.
 ```ruby
 grafana_plugin grafana-clock-panel do
   action :install
-  grafana_cli_bin '/usr/sbin/grafana-cli'
+  grafana_cli_bin '/usr/sbin/grafana cli'
 end
 ```
 

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -39,6 +39,7 @@ module Grafana
         raise "Invalid action [#{action.class}] #{action}" unless %i(install update upgrade remove list-remote ls).include?(action)
 
         plugin_cmd = new_resource.grafana_cli_bin.dup
+        plugin_cmd.concat(' --homepath /usr/share/grafana')
         plugin_cmd.concat(" --pluginUrl #{plugin_url}") if plugin_url
         plugin_cmd.concat(" plugins #{action}")
         plugin_cmd.concat(" #{name}") if name

--- a/resources/config_rendering.rb
+++ b/resources/config_rendering.rb
@@ -26,3 +26,5 @@ property :server_url, String
 property :callback_url, String
 
 property :concurrent_render_request_limit, Integer
+
+property :renderer_token, String

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -24,7 +24,7 @@ property :plugin_name, String,
           name_property: true
 
 property :grafana_cli_bin, String,
-          default: '/usr/sbin/grafana-cli'
+          default: '/usr/sbin/grafana cli'
 
 property :plugin_url, String
 

--- a/test/integration/plugins/plugins_spec.rb
+++ b/test/integration/plugins/plugins_spec.rb
@@ -1,4 +1,4 @@
-describe command('grafana-cli plugins ls') do
+describe command('grafana cli plugins ls') do
   its(:stdout) { should include 'grafana-clock-panel' }
   its(:stdout) { should include 'yesoreyeram-boomtable-panel' }
 end


### PR DESCRIPTION
- Change default grafana_cli_bin from grafana-cli to grafana cli
  - grafana-cli binary removed in Grafana 13.0.0
  - grafana cli subcommand available since Grafana 8.0
- Add --homepath /usr/share/grafana flag to plugin commands
- Add renderer_token property to config_rendering resource
- Update integration tests to use grafana cli
- Update documentation for plugin and config_rendering resources
- Remove stray lines from CHANGELOG

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
