### PR TITLE
fix: migrate to Policyfile and map Kitchen suites

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,16 +18,16 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependencies
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, kitchen tools.
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb                   # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/fixtures/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -2,11 +2,11 @@
 
 name 'grafana'
 
-default_source :supermarket
-
 run_list 'test::default'
 
 cookbook 'grafana', path: '.'
+cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
+cookbook 'curl', git: 'https://github.com/sous-chefs/curl.git', branch: 'main'
 cookbook 'test', path: './test/fixtures/cookbooks/test'
 
 named_run_list :azuread, 'test::azuread'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -5,8 +5,6 @@ name 'grafana'
 run_list 'test::default'
 
 cookbook 'grafana', path: '.'
-cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
-cookbook 'curl', git: 'https://github.com/sous-chefs/curl.git', branch: 'main'
 cookbook 'test', path: './test/fixtures/cookbooks/test'
 
 named_run_list :azuread, 'test::azuread'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+name 'grafana'
+
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'grafana', path: '.'
+cookbook 'test', path: './test/fixtures/cookbooks/test'
+
+named_run_list :azuread, 'test::azuread'
+named_run_list :basic, 'test::basic'
+named_run_list :config_plugins, 'test::config-plugins'
+named_run_list :configure, 'test::configure'
+named_run_list :default, 'test::default'
+named_run_list :ldap, 'test::ldap'
+named_run_list :plugins, 'test::plugins'
+named_run_list :proxy, 'test::proxy'

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 
@@ -98,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,33 +29,41 @@ platforms:
 
 suites:
   - name: default
+    named_run_list: default
     run_list:
       - recipe[test::default]
 
   - name: ldap
+    named_run_list: ldap
     run_list:
       - recipe[test::ldap]
 
   - name: proxy
+    named_run_list: proxy
     run_list:
       - recipe[test::proxy]
 
   - name: plugins
+    named_run_list: plugins
     run_list:
       - recipe[test::plugins]
 
   - name: basic
+    named_run_list: basic
     run_list:
       - recipe[test::basic]
 
   - name: configure
+    named_run_list: configure
     run_list:
       - recipe[test::configure]
 
   - name: azuread
+    named_run_list: azuread
     run_list:
       - recipe[test::azuread]
 
   - name: config-plugins
+    named_run_list: config_plugins
     run_list:
       - recipe[test::config-plugins]

--- a/libraries/_utils.rb
+++ b/libraries/_utils.rb
@@ -31,6 +31,22 @@ module Grafana
         values.any? { |v| v.nil? || (v.respond_to?(:empty?) && v.empty?) }
       end
 
+      # Recursively sort Hash keys for deterministic generated config output.
+      #
+      # @param value [Object] Value to sort
+      # @return [Object] Sorted value
+      #
+      def deep_sort(value)
+        case value
+        when Hash
+          value.sort_by { |key, _| key.to_s }.to_h { |key, nested_value| [key, deep_sort(nested_value)] }
+        when Array
+          value.map { |nested_value| deep_sort(nested_value) }
+        else
+          value
+        end
+      end
+
       # Check if a given gem is installed and available for require
       #
       # @return [true, false] Gem installed result

--- a/libraries/config.rb
+++ b/libraries/config.rb
@@ -126,7 +126,6 @@ module Grafana
                            end
 
         with_run_context(:root) do
-          declare_resource(:chef_gem, 'deepsort') { compile_time true } unless gem_installed?('deepsort')
           declare_resource(:chef_gem, 'inifile') { compile_time true } unless gem_installed?('inifile')
           declare_resource(:chef_gem, 'toml-rb') { compile_time true } unless gem_installed?('toml-rb')
 
@@ -161,7 +160,7 @@ module Grafana
       def accumulator_config_path_init(*path)
         init_config_template unless config_template_exist?
 
-        return config_file_template_variables if path.all? { |p| p.is_a?(NilClass) } # Root path specified
+        return config_file_template_variables if path.all?(NilClass) # Root path specified
         return config_file_template_variables.dig(*path) if config_file_template_variables.dig(*path).is_a?(Hash) # Return path if it exists
 
         Chef::Log.debug("accumulator_config_path_init: Initialising config file #{new_resource.config_file} path config#{path.map { |p| "['#{p}']" }.join}")

--- a/libraries/ini.rb
+++ b/libraries/ini.rb
@@ -18,7 +18,6 @@
 # limitations under the License.
 #
 
-require 'deepsort'
 require 'inifile'
 require_relative '_utils'
 
@@ -51,7 +50,7 @@ module Grafana
         content_compact = content.dup.compact
         global_settings = content_compact.delete('global')
 
-        content_compact.deep_sort!
+        content_compact = deep_sort(content_compact)
         content_compact.delete_if { |_, v| nil_or_empty?(v) }
 
         ::IniFile.new(content: { 'global' => global_settings }.merge(content_compact)).to_s.gsub("[global]\n", '')

--- a/libraries/toml.rb
+++ b/libraries/toml.rb
@@ -18,12 +18,14 @@
 # limitations under the License.
 #
 
-require 'deepsort'
 require 'toml-rb'
+require_relative '_utils'
 
 module Grafana
   module Cookbook
     module TomlHelper
+      include Grafana::Cookbook::Utils
+
       private
 
       # Load an toml file from disk
@@ -45,8 +47,7 @@ module Grafana
       def tomlfile_string(content, deep_sort: false)
         raise ArgumentError, "Expected Hash got #{content.class}" unless content.is_a?(Hash)
 
-        file_content = content
-        file_content.deep_sort! if deep_sort
+        file_content = deep_sort ? deep_sort(content) : content
 
         ::TomlRB.dump(file_content)
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,6 +21,5 @@ supports 'oracle'
 supports 'rocky'
 supports 'almalinux'
 
-gem 'deepsort'
 gem 'inifile'
 gem 'toml-rb', '~> 2.2'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -7,6 +7,3 @@ license           'Apache-2.0'
 description       'Testing cookbook for grafana'
 version           '0.0.1'
 depends           'grafana'
-
-depends 'apt'
-depends 'curl'


### PR DESCRIPTION
## Summary
- replace Berksfile dependency resolution with Policyfile.rb
- switch ChefSpec setup to Policyfile support where applicable
- update Copilot setup/docs away from berks install
- keep Policyfile.lock.json generated locally and ignored

## Verification
- chef install Policyfile.rb
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- chef exec rspec --format documentation equivalent via Workstation embedded RSpec
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-debian-12 --destroy=always